### PR TITLE
fix: 修复字幕列表分割后大幅跳动

### DIFF
--- a/blank-editor.html
+++ b/blank-editor.html
@@ -19446,7 +19446,10 @@ function confirmLinkedSplit() {
   flashHint('已按同一绝对时间切点联动拆分', 'success');
 }
 
-function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
+function splitAtCursor(
+  feedbackPoint = null,
+  { listFeedback = true, cueListAnchor: suppliedCueListAnchor = null } = {},
+) {
   if (!editingState) return false;
   const force = editingState.forceSplitArmed === true;
   const { el, idx, textEl } = editingState;
@@ -19572,6 +19575,14 @@ function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
     _dirty: true,
   };
 
+  // renderAll() 会重建整张字幕列表。content-visibility 会在重建后先用估算
+  // 行高占位，再为视口附近的行回填真实高度；只保存 scrollTop 无法阻止
+  // 当前字幕被累计行高误差顶走。列表来源的拆分因此保存原行的屏幕位置，
+  // 重绘后再用左半段恢复这个视觉锚点。
+  const cueListAnchor = listFeedback
+    ? suppliedCueListAnchor || captureCueListVisualAnchor(el)
+    : null;
+
   textEl.removeAttribute('contenteditable');
   el.classList.remove('editing');
   editingState = null;
@@ -19596,14 +19607,15 @@ function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
 
   rememberTemporaryVisibleSplitCues({ mainSegments: [leftSeg, rightSeg] });
   renderAll();
+  const leftEl = container.querySelector(`.cue[data-idx="${idx}"]`);
+  const rightEl = container.querySelector(`.cue[data-idx="${idx + 1}"]`);
   // 列表来源的拆分（B 键悬停行、列表右键拆分、行内编辑拆分）都发生在当前
-  // 可见的字幕行上，拆分后保持列表原滚动位置，不再把右半段滚到列表中央。
+  // 可见的字幕行上，拆分后让左半段留在原字幕的视觉位置；右半段自然排在
+  // 下一行。这样既保留 content-visibility，也不会被懒布局累计误差顶走。
   // 波形 / 编辑面板等其它来源的拆分结果可能不在列表视口内，仍滚动到新右半段，
   // 便于在列表中看到拆分结果。
-  if (!listFeedback) {
-    const rightEl = container.querySelector(`.cue[data-idx="${idx + 1}"]`);
-    if (rightEl) scrollCueToCenter(rightEl);
-  }
+  if (listFeedback) restoreCueListVisualAnchor(leftEl, cueListAnchor);
+  else if (rightEl) scrollCueToCenter(rightEl);
   selectOnly(idx + 1);
   // 拆分后后半段是新的视觉选中项，也必须成为 Shift+点击的范围锚点。
   lastClickedIdx = idx + 1;
@@ -19673,6 +19685,11 @@ function flashSplitFeedback({ index, track = 'main', splitMs, feedbackPoint = nu
 function splitFromContextMenu(idx, x, y, waveformTimeMs = null) {
   const el = container.querySelector(`.cue[data-idx="${idx}"]`);
   if (!el) return false;
+  // 从非编辑态按 B / 右键拆分时，startEdit() 可能让当前行先发生一次布局
+  // 变化；锚点必须取自用户按键前看到的位置，而不是临时编辑态的位置。
+  const cueListAnchor = Number.isFinite(waveformTimeMs)
+    ? null
+    : captureCueListVisualAnchor(el);
   const waveformFeedbackPoint = Number.isFinite(waveformTimeMs)
     ? waveformEditor?.getSplitPointAtTime?.(waveformTimeMs, 'main') || null
     : null;
@@ -19730,7 +19747,7 @@ function splitFromContextMenu(idx, x, y, waveformTimeMs = null) {
   if (Number.isFinite(caretInfo?.offset)) setEditingCaretOffset(caretInfo.offset);
   return splitAtCursor(
     { clientX: markerX, clientY: caretInfo?.rect?.top ?? y },
-    { listFeedback: true },
+    { listFeedback: true, cueListAnchor },
   );
 }
 
@@ -20296,6 +20313,40 @@ function cueListVisibleBounds() {
     ? Math.min(containerRect.bottom, Math.max(containerRect.top, toolbarRect.bottom))
     : containerRect.top;
   return { containerRect, top, bottom: containerRect.bottom };
+}
+
+let cueListVisualAnchorGeneration = 0;
+
+function captureCueListVisualAnchor(cueEl) {
+  if (!cueEl?.isConnected || cueEl.classList.contains('hidden')) return null;
+  const top = cueEl.getBoundingClientRect().top;
+  return Number.isFinite(top) ? { top } : null;
+}
+
+function restoreCueListVisualAnchor(cueEl, anchor) {
+  if (!cueEl?.isConnected || !Number.isFinite(anchor?.top)) return;
+  const generation = ++cueListVisualAnchorGeneration;
+  const maxFrames = 12;
+  const epsilon = 0.75;
+  let frameCount = 0;
+
+  const restore = () => {
+    if (generation !== cueListVisualAnchorGeneration || !cueEl.isConnected) return;
+    const delta = cueEl.getBoundingClientRect().top - anchor.top;
+    if (!Number.isFinite(delta)) return;
+    if (Math.abs(delta) > epsilon) {
+      const previousScrollTop = container.scrollTop;
+      container.scrollTop += delta;
+      // 到达列表边界、无法继续补偿时无需再占用后续动画帧。
+      if (Math.abs(container.scrollTop - previousScrollTop) < epsilon) return;
+    }
+    frameCount += 1;
+    // content-visibility 可能先稳定几帧，再因滚动到新的行而继续回填真实
+    // 高度；短暂覆盖完整观察窗口，避免连续拆分时出现延迟的二次位移。
+    if (frameCount < maxFrames) requestAnimationFrame(restore);
+  };
+
+  restore();
 }
 
 function scrollCueToCenter(cueEl, { behavior = 'smooth' } = {}) {

--- a/tests/e2e/click-behavior.spec.mjs
+++ b/tests/e2e/click-behavior.spec.mjs
@@ -551,9 +551,9 @@ test('B splits at the pointer inside the cue list and at the playhead outside it
   await expect(page.locator('.cue-split-flash.is-active')).toHaveCount(0);
 });
 
-test('B split inside the cue list keeps the list scroll position', async ({ page }) => {
+test('B split keeps the source cue visually anchored while lazy rows relayout', async ({ page }) => {
   await page.goto(server.url);
-  // 关闭「点击自动滚动」，避免点击选中行时先把列表滚到中央，干扰拆分滚动断言。
+  // 关闭「点击自动滚动」，只观察拆分重绘和 content-visibility 行高回填。
   await page.evaluate(() => {
     const saved = JSON.parse(localStorage.getItem('moy.asr.editor.settings.v1') || '{}');
     saved.cueListAutoScrollOnClick = false;
@@ -561,42 +561,47 @@ test('B split inside the cue list keeps the list scroll position', async ({ page
   });
   await page.reload();
   await page.evaluate(() => {
-    DATA.segments.push(...Array.from({ length: 34 }, (_, offset) => {
-      const index = DATA.segments.length + offset;
-      const start = index * 5000;
-      return { start, end: start + 1000, text: `Extra ${index}`, items: [] };
-    }));
+    const samples = [
+      '短字幕',
+      '这是一条会在字幕列表里自动换行的真实长度字幕',
+      '较长字幕用于模拟采访视频中的自然断句和不同的列表行高',
+      '中等长度字幕内容',
+    ];
+    DATA.segments = Array.from({ length: 90 }, (_, index) => {
+      const start = index * 2000;
+      return {
+        start,
+        end: start + 1800,
+        text: `${samples[index % samples.length]} ${index}`,
+        items: [],
+      };
+    });
     renderAll();
-    // 先滚到底再滚回目标行：content-visibility 会让视口外的行按
-    // contain-intrinsic-size 惰性重排，触发浏览器滚动锚定持续微调 scrollTop；
-    // 先让所有行完成一次重排，之后的滚动位置才是稳定的。
-    const list = document.getElementById('cues-container');
-    list.scrollTop = list.scrollHeight;
-    void list.scrollHeight;
+    document.querySelector('.cue[data-idx="56"]').scrollIntoView({ block: 'center' });
   });
-  await page.waitForTimeout(400);
-  await page.evaluate(() => {
-    const list = document.getElementById('cues-container');
-    document.querySelector('.cue[data-idx="30"]').scrollIntoView({ block: 'start' });
-    void list.scrollHeight;
-  });
-  // 等滚动锚定完全稳定后再记录基准位置。
+
+  // 只等目标附近的可见行稳定，不能滚遍整张列表预热，否则会掩盖重绘后的
+  // 懒布局回填问题。
   await expect.poll(async () => {
-    const a = await page.evaluate(() => document.getElementById('cues-container').scrollTop);
-    await page.waitForTimeout(150);
-    const b = await page.evaluate(() => document.getElementById('cues-container').scrollTop);
-    return a === b;
-  }, { timeout: 4000 }).toBe(true);
-  const before = await page.evaluate(() => document.getElementById('cues-container').scrollTop);
-  expect(before).toBeGreaterThan(0);
-  const target = page.locator('.cue[data-idx="30"]');
+    const first = await page.locator('.cue[data-idx="56"]').evaluate(
+      (element) => element.getBoundingClientRect().top,
+    );
+    await page.waitForTimeout(100);
+    const second = await page.locator('.cue[data-idx="56"]').evaluate(
+      (element) => element.getBoundingClientRect().top,
+    );
+    return Math.abs(first - second);
+  }, { timeout: 4000 }).toBeLessThan(0.5);
+
+  const target = page.locator('.cue[data-idx="56"]');
   const text = target.locator('.text');
-  // 点击位置直接落在文字第 5 个字符后，B 拆分的文字偏移可预期（Extra｜30）。
+  // 点击位置直接落在文字中间，确保左右两段都有效。
   const splitPoint = await text.evaluate((element) => {
     const node = element.firstChild;
     const range = document.createRange();
-    range.setStart(node, 5);
-    range.setEnd(node, 5);
+    const offset = Math.floor(node.textContent.length / 2);
+    range.setStart(node, offset);
+    range.setEnd(node, offset);
     const rect = range.getBoundingClientRect();
     return { x: rect.x, y: rect.y + rect.height / 2 };
   });
@@ -608,13 +613,49 @@ test('B split inside the cue list keeps the list scroll position', async ({ page
   await expect(target).toHaveClass(/selected/);
   await page.mouse.move(splitPoint.x, splitPoint.y);
   await expect(page.locator('.cue-split-preview')).toHaveCount(1);
+  const beforeTop = await target.evaluate((element) => element.getBoundingClientRect().top);
   await page.keyboard.press('b');
 
-  await expect.poll(() => page.locator('.cue').count()).toBe(41);
-  await expect(page.locator('.cue[data-idx="31"]')).toHaveClass(/selected/);
-  await expect(page.locator('.cue .text').nth(30)).toHaveText('Extra');
-  await expect(page.locator('.cue .text').nth(31)).toHaveText('30');
-  await expect.poll(() => page.evaluate(() => document.getElementById('cues-container').scrollTop)).toBe(before);
+  await expect.poll(() => page.locator('.cue').count()).toBe(91);
+  const left = page.locator('.cue[data-idx="56"]');
+  const right = page.locator('.cue[data-idx="57"]');
+  await expect(right).toHaveClass(/selected/);
+  await expect.poll(async () => {
+    const currentTop = await left.evaluate((element) => element.getBoundingClientRect().top);
+    return Math.abs(currentTop - beforeTop);
+  }).toBeLessThan(1.5);
+  await expect(left).toHaveCSS('content-visibility', 'auto');
+
+  // 连续拆分新生成的右半段，也不能让累计行高误差把当前工作位置越推越远。
+  const secondText = right.locator('.text');
+  const secondSplitPoint = await secondText.evaluate((element) => {
+    const node = element.firstChild;
+    const range = document.createRange();
+    const offset = Math.max(1, Math.floor(node.textContent.length / 2));
+    range.setStart(node, offset);
+    range.setEnd(node, offset);
+    const rect = range.getBoundingClientRect();
+    return { x: rect.x, y: rect.y + rect.height / 2 };
+  });
+  await right.dispatchEvent('pointerdown', {
+    bubbles: true, button: 0, buttons: 1, pointerId: 1,
+    clientX: secondSplitPoint.x, clientY: secondSplitPoint.y,
+  });
+  await right.dispatchEvent('click', {
+    bubbles: true, detail: 1,
+    clientX: secondSplitPoint.x, clientY: secondSplitPoint.y,
+  });
+  await page.mouse.move(secondSplitPoint.x, secondSplitPoint.y);
+  const secondBeforeTop = await right.evaluate((element) => element.getBoundingClientRect().top);
+  await page.keyboard.press('b');
+
+  await expect.poll(() => page.locator('.cue').count()).toBe(92);
+  const secondLeft = page.locator('.cue[data-idx="57"]');
+  await expect(page.locator('.cue[data-idx="58"]')).toHaveClass(/selected/);
+  await expect.poll(async () => {
+    const currentTop = await secondLeft.evaluate((element) => element.getBoundingClientRect().top);
+    return Math.abs(currentTop - secondBeforeTop);
+  }).toBeLessThan(1.5);
 });
 
 test('B flashes a yellow marker after splitting at the waveform pointer without a selection', async ({ page }) => {

--- a/web/editor.js
+++ b/web/editor.js
@@ -6201,7 +6201,10 @@ function confirmLinkedSplit() {
   flashHint('已按同一绝对时间切点联动拆分', 'success');
 }
 
-function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
+function splitAtCursor(
+  feedbackPoint = null,
+  { listFeedback = true, cueListAnchor: suppliedCueListAnchor = null } = {},
+) {
   if (!editingState) return false;
   const force = editingState.forceSplitArmed === true;
   const { el, idx, textEl } = editingState;
@@ -6327,6 +6330,14 @@ function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
     _dirty: true,
   };
 
+  // renderAll() 会重建整张字幕列表。content-visibility 会在重建后先用估算
+  // 行高占位，再为视口附近的行回填真实高度；只保存 scrollTop 无法阻止
+  // 当前字幕被累计行高误差顶走。列表来源的拆分因此保存原行的屏幕位置，
+  // 重绘后再用左半段恢复这个视觉锚点。
+  const cueListAnchor = listFeedback
+    ? suppliedCueListAnchor || captureCueListVisualAnchor(el)
+    : null;
+
   textEl.removeAttribute('contenteditable');
   el.classList.remove('editing');
   editingState = null;
@@ -6351,14 +6362,15 @@ function splitAtCursor(feedbackPoint = null, { listFeedback = true } = {}) {
 
   rememberTemporaryVisibleSplitCues({ mainSegments: [leftSeg, rightSeg] });
   renderAll();
+  const leftEl = container.querySelector(`.cue[data-idx="${idx}"]`);
+  const rightEl = container.querySelector(`.cue[data-idx="${idx + 1}"]`);
   // 列表来源的拆分（B 键悬停行、列表右键拆分、行内编辑拆分）都发生在当前
-  // 可见的字幕行上，拆分后保持列表原滚动位置，不再把右半段滚到列表中央。
+  // 可见的字幕行上，拆分后让左半段留在原字幕的视觉位置；右半段自然排在
+  // 下一行。这样既保留 content-visibility，也不会被懒布局累计误差顶走。
   // 波形 / 编辑面板等其它来源的拆分结果可能不在列表视口内，仍滚动到新右半段，
   // 便于在列表中看到拆分结果。
-  if (!listFeedback) {
-    const rightEl = container.querySelector(`.cue[data-idx="${idx + 1}"]`);
-    if (rightEl) scrollCueToCenter(rightEl);
-  }
+  if (listFeedback) restoreCueListVisualAnchor(leftEl, cueListAnchor);
+  else if (rightEl) scrollCueToCenter(rightEl);
   selectOnly(idx + 1);
   // 拆分后后半段是新的视觉选中项，也必须成为 Shift+点击的范围锚点。
   lastClickedIdx = idx + 1;
@@ -6428,6 +6440,11 @@ function flashSplitFeedback({ index, track = 'main', splitMs, feedbackPoint = nu
 function splitFromContextMenu(idx, x, y, waveformTimeMs = null) {
   const el = container.querySelector(`.cue[data-idx="${idx}"]`);
   if (!el) return false;
+  // 从非编辑态按 B / 右键拆分时，startEdit() 可能让当前行先发生一次布局
+  // 变化；锚点必须取自用户按键前看到的位置，而不是临时编辑态的位置。
+  const cueListAnchor = Number.isFinite(waveformTimeMs)
+    ? null
+    : captureCueListVisualAnchor(el);
   const waveformFeedbackPoint = Number.isFinite(waveformTimeMs)
     ? waveformEditor?.getSplitPointAtTime?.(waveformTimeMs, 'main') || null
     : null;
@@ -6485,7 +6502,7 @@ function splitFromContextMenu(idx, x, y, waveformTimeMs = null) {
   if (Number.isFinite(caretInfo?.offset)) setEditingCaretOffset(caretInfo.offset);
   return splitAtCursor(
     { clientX: markerX, clientY: caretInfo?.rect?.top ?? y },
-    { listFeedback: true },
+    { listFeedback: true, cueListAnchor },
   );
 }
 
@@ -7051,6 +7068,40 @@ function cueListVisibleBounds() {
     ? Math.min(containerRect.bottom, Math.max(containerRect.top, toolbarRect.bottom))
     : containerRect.top;
   return { containerRect, top, bottom: containerRect.bottom };
+}
+
+let cueListVisualAnchorGeneration = 0;
+
+function captureCueListVisualAnchor(cueEl) {
+  if (!cueEl?.isConnected || cueEl.classList.contains('hidden')) return null;
+  const top = cueEl.getBoundingClientRect().top;
+  return Number.isFinite(top) ? { top } : null;
+}
+
+function restoreCueListVisualAnchor(cueEl, anchor) {
+  if (!cueEl?.isConnected || !Number.isFinite(anchor?.top)) return;
+  const generation = ++cueListVisualAnchorGeneration;
+  const maxFrames = 12;
+  const epsilon = 0.75;
+  let frameCount = 0;
+
+  const restore = () => {
+    if (generation !== cueListVisualAnchorGeneration || !cueEl.isConnected) return;
+    const delta = cueEl.getBoundingClientRect().top - anchor.top;
+    if (!Number.isFinite(delta)) return;
+    if (Math.abs(delta) > epsilon) {
+      const previousScrollTop = container.scrollTop;
+      container.scrollTop += delta;
+      // 到达列表边界、无法继续补偿时无需再占用后续动画帧。
+      if (Math.abs(container.scrollTop - previousScrollTop) < epsilon) return;
+    }
+    frameCount += 1;
+    // content-visibility 可能先稳定几帧，再因滚动到新的行而继续回填真实
+    // 高度；短暂覆盖完整观察窗口，避免连续拆分时出现延迟的二次位移。
+    if (frameCount < maxFrames) requestAnimationFrame(restore);
+  };
+
+  restore();
 }
 
 function scrollCueToCenter(cueEl, { behavior = 'smooth' } = {}) {


### PR DESCRIPTION
## 问题

在字幕列表使用 B、右键或行内拆分时，renderAll 会重建整张列表。content-visibility 先用估算行高占位，再回填真实行高；原逻辑只保持 scrollTop 数值，导致当前字幕被前面多行的累计误差一次顶走。现有测试又提前预热全部行并只检查 scrollTop，因此没有覆盖用户看到的视觉位移。

## 修改

- 在进入临时编辑态前记录源字幕行的屏幕位置。
- 列表重建后，以新左半段恢复视觉锚点，并在短暂动画帧窗口内覆盖延迟行高回填。
- 保留 content-visibility 懒加载；波形和编辑面板来源的拆分定位逻辑不变。
- 将回归测试改为 90 条不同长度、会换行且未预热的字幕，并覆盖连续两次 B 分割。

## 验证

- Chrome 交互测试：29 项通过。
- 前端单元测试：166 项通过。
- Python 测试：689 项通过，5 项跳过。
- 变基到最新 main 后，修复专项 Chromium 用例再次通过。