### PR TITLE
fix: Linux appImage 打开外部程序前恢复 LD_LIBRARY_PATH

### DIFF
--- a/maw/gui_web.py
+++ b/maw/gui_web.py
@@ -1058,7 +1058,7 @@ class LauncherApi:
         url = str(payload.get("url") or "").strip()
         if not url.startswith(("https://", "http://")):
             return {"ok": False, "error": "Invalid URL."}
-        webbrowser.open(url)
+        _open_external(url)
         return {"ok": True}
 
     def open_file(self, payload: Mapping[str, object]) -> dict[str, object]:
@@ -2533,6 +2533,19 @@ def _stop_external_maw_server(port: int) -> bool:
     return result.returncode == 0
 
 
+def _open_external(target: str) -> None:
+    if sys.platform == "linux" and getattr(sys, "frozen", False):
+        env = os.environ.copy()
+        original = env.get("LD_LIBRARY_PATH_ORIG")
+        if original is not None:
+            env["LD_LIBRARY_PATH"] = original
+        else:
+            env.pop("LD_LIBRARY_PATH", None)
+        subprocess.Popen(["xdg-open", target], env=env)
+    else:
+        webbrowser.open(target)
+
+
 def _open_existing_path(path: Path) -> dict[str, object]:
     target = Path(path).expanduser()
     if not target.exists():
@@ -2540,7 +2553,7 @@ def _open_existing_path(path: Path) -> dict[str, object]:
     if os.name == "nt":
         os.startfile(str(target))
     else:
-        webbrowser.open(target.resolve().as_uri())
+        _open_external(target.resolve().as_uri())
     return {"ok": True}
 
 

--- a/tests/test_gui_web.py
+++ b/tests/test_gui_web.py
@@ -18,7 +18,7 @@ from urllib.error import URLError
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from maw.gui_web import EventPump, LauncherApi, LauncherPaths, PreflightError, SERVER_START_TIMEOUT, _emoji_font_urls, _find_mose_executable, _is_ffmpeg_start_failure, _is_ffprobe_start_failure, _port, _register_mosp_association, _request_from_payload, _route_dropped_path, _valid_emoji_font, default_paths, download_emoji_font, run_app  # noqa: E402
+from maw.gui_web import EventPump, LauncherApi, LauncherPaths, PreflightError, SERVER_START_TIMEOUT, _emoji_font_urls, _find_mose_executable, _is_ffmpeg_start_failure, _is_ffprobe_start_failure, _open_existing_path, _open_external, _port, _register_mosp_association, _request_from_payload, _route_dropped_path, _valid_emoji_font, default_paths, download_emoji_font, run_app  # noqa: E402
 from maw.gui_workflow import TranscriptionCancelledError, TranscriptionProcessError, TranscriptionRequest, TranscriptionResult  # noqa: E402
 from maw.local_models import LocalModelStatus  # noqa: E402
 
@@ -915,6 +915,77 @@ class GuiWebBridgeTests(unittest.TestCase):
         self.assertTrue(result["usedMose"])
         self.assertEqual(popen.call_args.args[0], [str(executable), str(project.resolve())])
         self.assertEqual(popen.call_args.kwargs["cwd"], str(self.root))
+
+    def test_open_url_uses_external_opener(self) -> None:
+        with mock.patch("maw.gui_web._open_external") as open_external:
+            result = self.api.open_url({"url": "https://example.com/docs"})
+
+        self.assertEqual(result, {"ok": True})
+        open_external.assert_called_once_with("https://example.com/docs")
+
+    def test_open_external_restores_original_library_path_for_frozen_linux(self) -> None:
+        parent_env = {
+            "LD_LIBRARY_PATH": "/app/_internal",
+            "LD_LIBRARY_PATH_ORIG": "/run/current-system/sw/lib",
+            "MAW_TEST": "preserved",
+        }
+        with mock.patch.object(sys, "platform", "linux"):
+            with mock.patch.object(sys, "frozen", True, create=True):
+                with mock.patch.dict(os.environ, parent_env, clear=True):
+                    with mock.patch("maw.gui_web.subprocess.Popen") as popen:
+                        _open_external("https://example.com/docs")
+                    self.assertEqual(dict(os.environ), parent_env)
+
+        popen.assert_called_once()
+        self.assertEqual(popen.call_args.args[0], ["xdg-open", "https://example.com/docs"])
+        child_env = popen.call_args.kwargs["env"]
+        self.assertEqual(child_env["LD_LIBRARY_PATH"], "/run/current-system/sw/lib")
+        self.assertEqual(child_env["LD_LIBRARY_PATH_ORIG"], "/run/current-system/sw/lib")
+        self.assertEqual(child_env["MAW_TEST"], "preserved")
+
+    def test_open_external_removes_library_path_without_original_for_frozen_linux(self) -> None:
+        parent_env = {"LD_LIBRARY_PATH": "/app/_internal", "MAW_TEST": "preserved"}
+        with mock.patch.object(sys, "platform", "linux"):
+            with mock.patch.object(sys, "frozen", True, create=True):
+                with mock.patch.dict(os.environ, parent_env, clear=True):
+                    with mock.patch("maw.gui_web.subprocess.Popen") as popen:
+                        _open_external("file:///tmp/example.html")
+                    self.assertEqual(dict(os.environ), parent_env)
+
+        child_env = popen.call_args.kwargs["env"]
+        self.assertNotIn("LD_LIBRARY_PATH", child_env)
+        self.assertEqual(child_env["MAW_TEST"], "preserved")
+
+    def test_open_external_uses_webbrowser_when_not_frozen(self) -> None:
+        with mock.patch.object(sys, "platform", "linux"):
+            with mock.patch.object(sys, "frozen", False, create=True):
+                with mock.patch("maw.gui_web.subprocess.Popen") as popen:
+                    with mock.patch("maw.gui_web.webbrowser.open") as open_browser:
+                        _open_external("https://example.com/docs")
+
+        open_browser.assert_called_once_with("https://example.com/docs")
+        popen.assert_not_called()
+
+    @unittest.skipIf(os.name == "nt", "Non-Windows paths use the external opener")
+    def test_open_existing_path_uses_external_opener_for_file_and_folder(self) -> None:
+        artifact = self.root / "clip.edit.html"
+        directory = self.root / "output"
+        artifact.write_text("<!doctype html>\n", encoding="utf-8")
+        directory.mkdir()
+
+        with mock.patch("maw.gui_web._open_external") as open_external:
+            file_result = _open_existing_path(artifact)
+            folder_result = _open_existing_path(directory)
+
+        self.assertEqual(file_result, {"ok": True})
+        self.assertEqual(folder_result, {"ok": True})
+        self.assertEqual(
+            open_external.call_args_list,
+            [
+                mock.call(artifact.resolve().as_uri()),
+                mock.call(directory.resolve().as_uri()),
+            ],
+        )
 
     def test_open_file_opens_existing_chain_artifact(self) -> None:
         artifact = self.root / "clip.llm.mosp"


### PR DESCRIPTION
MAW 此前使用 `webbrowser.open()` 打开 URL，以及非 Windows 平台上的 HTML、文件和文件夹，PyInstaller AppImage 会修改 `LD_LIBRARY_PATH`，而 MAW 调用 `xdg-open` 时，这个环境变量也会被系统程序继承

#69 我在 NixOS 上确认了这一问题：系统 Bash 曾误加载 AppImage 内的 `libreadline`。#71 通过排除 `libreadline` 修复了该具体冲突，但没有解决外部程序继承 PyInstaller 动态库环境的通用问题，在我设备上的表现是：点击“启动字幕编辑器”或类似链接后，浏览器未自动启动，但没有 `libreadline` 的报错

该问题大概并不局限于 NixOS，只要 AppImage 内的动态库与系统程序不兼容，其他 Linux 发行版也可能复现

### 修改内容

在 `maw/gui_web.py` 中新增统一的 `_open_external()`

**仅在 PyInstaller frozen Linux 环境下：**

- 复制当前环境，不修改 MAW 自身的 `os.environ`
- 如果存在 `LD_LIBRARY_PATH_ORIG`，将子进程的 `LD_LIBRARY_PATH` 恢复为该值
- 如果不存在 `LD_LIBRARY_PATH_ORIG`，从子进程环境中删除 `LD_LIBRARY_PATH`
- 使用清理后的环境启动系统 `xdg-open`

URL、文件和文件夹现在都会走该统一入口

**非 frozen 环境及其他平台：**

- Linux 源码运行：`webbrowser.open()`
- macOS：`webbrowser.open()`
- Windows 文件和文件夹：`os.startfile()`
- Windows URL：`webbrowser.open()`

#71 中对 `libreadline` 的排除保留

### 代码片段

```python
def _open_external(target: str) -> None:
    if sys.platform == "linux" and getattr(sys, "frozen", False):
        env = os.environ.copy()
        original = env.get("LD_LIBRARY_PATH_ORIG")

        if original is not None:
            env["LD_LIBRARY_PATH"] = original
        else:
            env.pop("LD_LIBRARY_PATH", None)

        subprocess.Popen(["xdg-open", target], env=env)
    else:
        webbrowser.open(target)
```

**相关文档：** https://pyinstaller.org/en/stable/runtime-information.html

### 测试（大量 vibe 警告 xx）
~~应该是能用的 x~~

- frozen Linux 下将 `LD_LIBRARY_PATH` 恢复为 `LD_LIBRARY_PATH_ORIG`
- 不存在 `LD_LIBRARY_PATH_ORIG` 时删除子进程的 `LD_LIBRARY_PATH`
- 复制并保留其他环境变量
- MAW 自身的 `os.environ` 不被修改
- 非 frozen Linux 继续使用 `webbrowser.open()`
- URL 经过统一外部打开入口
- 文件和文件夹经过统一外部打开入口

**本地验证结果：**

- 定向回归测试 5 项通过
- Python 全套测试 714 项通过，5 项跳过：
1 个 Windows 平台专用测试
1 个 REAPER fixture 测试类初始化
3 个需要 numpy 的 fixture 对比测试
- Ruff 通过
- `git diff --check` 通过

**GitHub CI ~~（柴老师在我不在旁边给它开 CI 的情况下自己提了个 PR 搞到了 x）~~：**
~~已经严厉批评过柴老师，并加入自己的 AGENTS.md~~

- [Release MAW GUI run 32990907586](https://github.com/hatanokokosa/moys-asr-workflow/actions/runs/32990907586)
- Linux x86_64 AppImage 构建及 headless smoke：通过
- Windows x64 构建：通过
- macOS arm64 构建：通过

**手动验证：**

- 使用 CI 构建的 AppImage 在 NixOS 上完成验证
- Server、外部链接、文件和文件夹可以正常打开，浏览器正常跳转
- MAW 自身及内部子进程行为未受影响

### **未验证内容**

- NixOS 以外的 Linux 发行版上的手动验证
- Windows 和 macOS 已通过 CI 构建及测试，但没有手动交互验证

Closes #69 