### PR TITLE
fix: 补齐 macOS/Linux 本地运行环境引导

### DIFF
--- a/.github/workflows/pr-release-windows.yml
+++ b/.github/workflows/pr-release-windows.yml
@@ -49,12 +49,6 @@ jobs:
       - name: Run Python tests
         run: uv run python -m unittest discover -s tests -p "test_*.py"
 
-      - name: Download embedded Python bootstrap assets
-        run: |
-          mkdir -p build
-          curl -L --retry 3 --connect-timeout 20 --max-time 300 -o build/python-3.11.9-embed-amd64.zip https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip
-          curl -L --retry 3 --connect-timeout 20 --max-time 120 -o build/get-pip.py https://bootstrap.pypa.io/get-pip.py
-
       - name: Build MAW bundle
         shell: pwsh
         run: .\scripts\build-windows.ps1 -SkipTests
@@ -75,6 +69,8 @@ jobs:
             '_internal\local-runtime\requirements-local.txt'
             '_internal\ocr-runtime\requirements-ocr.txt'
             '_internal\moss-runtime\requirements-moss.txt'
+            '_internal\bootstrap\python-3.11.9-embed-amd64.zip'
+            '_internal\bootstrap\get-pip.py'
           )
           foreach ($Relative in $Required) {
             $Path = Join-Path 'dist\MAW' $Relative

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -33,3 +33,35 @@ jobs:
 
       - name: Run Ruff check
         run: uv run --frozen ruff check
+
+  runtime-bootstrap-smoke:
+    name: Runtime bootstrap smoke (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS arm64
+            os: macos-14
+            arch: arm64
+            platform: macos-arm64
+          - name: Linux x86_64
+            os: ubuntu-22.04
+            arch: x64
+            platform: linux-x86_64
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: ${{ matrix.arch }}
+
+      - name: Prepare runtime bootstrap
+        run: python scripts/prepare_runtime_bootstrap.py --platform ${{ matrix.platform }}
+
+      - name: Smoke runtime bootstrap
+        run: python scripts/smoke_runtime_bootstrap.py --platform ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,6 @@ jobs:
       - name: Run Python tests
         run: uv run python -m unittest discover -s tests -p "test_*.py"
 
-      - name: Download embedded Python bootstrap assets
-        run: |
-          mkdir -p build
-          curl -L --retry 3 --connect-timeout 20 --max-time 300 -o build/python-3.11.9-embed-amd64.zip https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip
-          curl -L --retry 3 --connect-timeout 20 --max-time 120 -o build/get-pip.py https://bootstrap.pypa.io/get-pip.py
-
       - name: Build MAW bundle
         shell: pwsh
         run: .\scripts\build-windows.ps1 -SkipTests
@@ -127,6 +121,8 @@ jobs:
             '_internal\local-runtime\requirements-local.txt'
             '_internal\ocr-runtime\requirements-ocr.txt'
             '_internal\moss-runtime\requirements-moss.txt'
+            '_internal\bootstrap\python-3.11.9-embed-amd64.zip'
+            '_internal\bootstrap\get-pip.py'
           )
           foreach ($Relative in $Required) {
             $Path = Join-Path 'dist\MAW' $Relative
@@ -317,6 +313,8 @@ jobs:
       - name: Build MAW GUI bundle
         if: matrix.platform == 'macos'
         run: |
+          uv run python scripts/prepare_runtime_bootstrap.py --platform macos-arm64
+          uv run python scripts/smoke_runtime_bootstrap.py --platform macos-arm64
           uv export --frozen --extra local --no-dev --format requirements-txt -o build/requirements-local.txt
           uv export --frozen --extra ocr --no-dev --format requirements-txt -o build/requirements-ocr.txt
           uv pip compile moss-requirements.in -p 3.11 --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match -o build/requirements-moss.txt
@@ -343,6 +341,8 @@ jobs:
               exit 1
             fi
           done
+          test -f "dist/MAW.app/Contents/Resources/bootstrap/cpython-3.11.16+20260825-aarch64-apple-darwin-install_only_stripped.tar.gz"
+          test -f "dist/MAW.app/Contents/Resources/bootstrap/get-pip.py"
           echo "OK: runtime requirements txt 随包分发"
 
       - name: Smoke MAW executable
@@ -525,6 +525,8 @@ jobs:
           test -f squashfs-root/_internal/local-runtime/requirements-local.txt
           test -f squashfs-root/_internal/ocr-runtime/requirements-ocr.txt
           test -f squashfs-root/_internal/moss-runtime/requirements-moss.txt
+          test -f "squashfs-root/_internal/bootstrap/cpython-3.11.16+20260825-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+          test -f squashfs-root/_internal/bootstrap/get-pip.py
           echo "OK: runtime requirements txt 随包分发"
           rm -r squashfs-root
 

--- a/MAW.spec
+++ b/MAW.spec
@@ -3,13 +3,17 @@
 import sys
 from pathlib import Path
 
+ROOT = Path(SPECPATH).resolve()
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from maw.runtime_bootstrap import GET_PIP_ASSET, asset_matches, current_python_bootstrap
+
 try:
     from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 except ImportError:  # pragma: no cover - only reached outside a PyInstaller build
     collect_data_files = lambda _package: []
     collect_submodules = lambda _package: []
-
-ROOT = Path(SPECPATH).resolve()
 
 binaries = []
 if sys.platform == "linux":
@@ -80,6 +84,21 @@ datas = [
     (str(ROOT / "maw" / "project_preview.py"), "ocr-runtime/maw"),
     (str(ROOT / "maw" / "ocr_runtime_worker.py"), "ocr-runtime/maw"),
 ]
+
+# 所有官方产物都必须携带当前平台 Python 引导包和固定 get-pip.py。
+# 构建入口在 PyInstaller 前运行 prepare_runtime_bootstrap.py；这里
+# 故意严格失败，防止生成“可打开但无法安装 Runtime”的坏包。
+_python_bootstrap = current_python_bootstrap()
+_bootstrap_root = ROOT / "build" / "bootstrap"
+for _bootstrap_asset in (_python_bootstrap.asset, GET_PIP_ASSET):
+    _bootstrap_path = _bootstrap_root / _bootstrap_asset.filename
+    if not asset_matches(_bootstrap_path, _bootstrap_asset):
+        raise SystemExit(
+            f"Missing or invalid runtime bootstrap asset: {_bootstrap_path}. "
+            "Run scripts/prepare_runtime_bootstrap.py before PyInstaller."
+        )
+    datas.append((str(_bootstrap_path), "bootstrap"))
+
 opencc_datas = collect_data_files("opencc")
 datas.extend(opencc_datas)
 # 托管 Runtime 依赖清单（CI 构建时 uv export / uv pip compile 生成，frozen
@@ -133,6 +152,7 @@ a = Analysis(
         "maw.media_cache",
         "maw.waveform",
         "maw.reapeaks",
+        "maw.runtime_bootstrap",
         "generate_subtitle_qwen_api",
         "generate_subtitle_soniox_api",
         "generate_subtitle_local",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-本仓库不打包模型或云端 API 服务。默认的 `MAW-Windows` 与 `MAW-macOS-arm64` 包会附带对应平台的 `ffmpeg` 与 `ffprobe`；可选的 `MAW-lite` 包不含 FFmpeg；Linux 的 `MAW-Linux-x86_64.AppImage` 始终内置静态 `ffmpeg`/`ffprobe`（BtbN 构建）。Windows 包还会在 `bootstrap/` 携带嵌入式 Python（python-3.11.9-embed-amd64.zip）与 `get-pip.py`，供用户通过 GUI 创建本地 ASR 运行环境。运行时可能使用下列外部组件；许可证和服务条款以各项目及服务方的最新文本为准。
+本仓库不打包模型或云端 API 服务。默认的 `MAW-Windows` 与 `MAW-macOS-arm64` 包会附带对应平台的 `ffmpeg` 与 `ffprobe`；可选的 `MAW-lite` 包不含 FFmpeg；Linux 的 `MAW-Linux-x86_64.AppImage` 始终内置静态 `ffmpeg`/`ffprobe`（BtbN 构建）。Windows x64、macOS arm64 和 Linux x86_64 包均会在 `bootstrap/` 携带匹配平台的 Python 3.11 引导归档与固定版 `get-pip.py`，供 GUI 创建可选本地运行环境。运行时可能使用下列外部组件；许可证和服务条款以各项目及服务方的最新文本为准。
 
 | Component | Purpose | License / terms |
 |---|---|---|
@@ -16,9 +16,9 @@
 | [PyQt6](https://riverbankcomputing.com/software/pyqt/) / [QtPy](https://github.com/spyder-ide/qtpy) | Linux desktop GUI backend for pywebview (Launcher) | PyQt6: GPL-3.0 or a commercial license from Riverbank Computing; Qt: LGPL-3.0 |
 | [Noto Color Emoji](https://github.com/googlefonts/noto-emoji) | Color emoji font for the Linux launcher keycap headers (1️⃣ etc.). On first launch the app downloads it to the user cache directory (`MAW_EMOJI_FONT_URL` can override the source), then the page references it locally; subsequent runs are offline. Not bundled or shipped. File sha256 at integration time: `72a635cb3d2f3524c51620cdde406b217204e8a6a06c6a096ff8ed4b5fd6e27b` | SIL OFL 1.1 |
 | [PyInstaller](https://pyinstaller.org/) | Build the optional Windows application bundle | GPL-2.0-or-later with a bootloader exception that permits distributing bundled applications |
-| [Python](https://www.python.org/) | Runtime embedded in the optional Windows application bundle | Python Software Foundation License |
+| [Python](https://www.python.org/) / [python-build-standalone](https://github.com/astral-sh/python-build-standalone) | Windows 使用官方 embeddable ZIP；macOS/Linux 使用固定的 standalone 发行归档 | Python Software Foundation License；python-build-standalone 构建工具为 MPL-2.0，归档内附组件许可文本 |
+| [get-pip](https://github.com/pypa/get-pip) | 为托管 Python 运行环境引导 pip | MIT |
 | [FFmpeg](https://ffmpeg.org/) / [Gyan Windows build](https://www.gyan.dev/ffmpeg/builds/) / [OSXExperts macOS build](https://www.osxexperts.net/) / [BtbN Linux build](https://github.com/BtbN/FFmpeg-Builds) | Inspect media, extract audio, and build waveform peaks | `MAW-Windows` includes FFmpeg 8.1.2 Essentials executables under GPL-3.0; `MAW-macOS-arm64` includes FFmpeg 8.1 Apple Silicon static `ffmpeg` and `ffprobe` binaries; the optional `MAW-lite` packages do not bundle FFmpeg; the Linux `MAW-Linux-x86_64.AppImage` bundles the BtbN `linux64-gpl` static `ffmpeg`/`ffprobe` build. The bundled `ffmpeg/` directory includes FFmpeg license files and source/provider references. |
-| [uv](https://github.com/astral-sh/uv) | Bootstrap a user-managed Python environment for optional local ASR | MIT or Apache-2.0; the bundled binary is obtained from the uv release used by the Windows build |
 | [Qwen3-ASR](https://github.com/QwenLM/Qwen3-ASR) / `qwen-asr` | Optional local Qwen speech-recognition runtime | Not installed by default and not bundled; runtime code and downloaded model checkpoints remain subject to their upstream licenses and terms |
 | [FunASR](https://github.com/modelscope/FunASR) / `funasr` | Optional local speech-recognition runtime | Not installed by default and not bundled; runtime code and downloaded model checkpoints remain subject to their upstream licenses and terms |
 | Alibaba Cloud Model Studio / Qwen ASR | Speech recognition API | External service; subject to Alibaba Cloud terms, billing, and privacy policy |

--- a/maw/local_runtime.py
+++ b/maw/local_runtime.py
@@ -35,7 +35,6 @@ from maw.runtimes.base import (
     resolve_model_cache_root,
 )
 from maw.runtimes.local_spec import (
-    EMBED_PYTHON_ZIP,
     PYTORCH_INDEX,
     PYTHON_VERSION,
     RUNTIME_VERSION,
@@ -44,7 +43,6 @@ from maw.runtimes.local_spec import (
 )
 
 __all__ = [
-    "EMBED_PYTHON_ZIP",
     "PYTORCH_INDEX",
     "PYTHON_VERSION",
     "RUNTIME_VERSION",

--- a/maw/moss_runtime.py
+++ b/maw/moss_runtime.py
@@ -6,7 +6,7 @@
 
 MOSS Transcribe-Diarize 依赖 Transformers 5.x，与 QwenASR / FunASR
 （funasr / Transformers 4.x 侧）不能共享一个环境，因此独立安装到
-``local-runtime-moss``（Python 3.11，与 local 共用同一 embedded zip）；
+``local-runtime-moss``（Python 3.11，与 local 共用当前平台引导包）；
 模型缓存与其余引擎共用。
 """
 
@@ -65,7 +65,7 @@ def install_local_runtime(
     repair: bool = False,
     model_cache_root: str | Path | None = None,
 ) -> LocalRuntimeStatus:
-    """创建或修复 MOSS 环境（embedded Python + pip --target + frozen txt）。"""
+    """创建或修复 MOSS 环境（平台 Python + pip --target + frozen txt）。"""
     return _from_runtime_status(
         MOSS.install(
             on_event=on_event,

--- a/maw/runtime_bootstrap.py
+++ b/maw/runtime_bootstrap.py
@@ -1,0 +1,289 @@
+"""托管 Runtime 共用的跨平台 Python 引导资产与解压逻辑。"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Final, Literal
+
+
+ArchiveFormat = Literal["zip", "tar.gz"]
+
+
+class RuntimeBootstrapError(RuntimeError):
+    """引导平台不受支持或归档不安全、不完整。"""
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapAsset:
+    """可重复下载并校验的单个构建资产。"""
+
+    filename: str
+    url: str
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class PythonBootstrap:
+    """一个受支持平台的 Python 引导契约。"""
+
+    key: str
+    asset: BootstrapAsset
+    archive_format: ArchiveFormat
+    archive_root: str
+    python_relative_path: str
+
+
+GET_PIP_ASSET: Final = BootstrapAsset(
+    filename="get-pip.py",
+    url=(
+        "https://raw.githubusercontent.com/pypa/get-pip/"
+        "f6f644156f23dfe9acc06e7b9ca75eee311f2e37/public/get-pip.py"
+    ),
+    sha256="fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6",
+)
+
+_BOOTSTRAPS: Final[dict[str, PythonBootstrap]] = {
+    "windows-x86_64": PythonBootstrap(
+        key="windows-x86_64",
+        asset=BootstrapAsset(
+            filename="python-3.11.9-embed-amd64.zip",
+            url="https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip",
+            sha256="009d6bf7e3b2ddca3d784fa09f90fe54336d5b60f0e0f305c37f400bf83cfd3b",
+        ),
+        archive_format="zip",
+        archive_root="",
+        python_relative_path="python.exe",
+    ),
+    "macos-arm64": PythonBootstrap(
+        key="macos-arm64",
+        asset=BootstrapAsset(
+            filename=(
+                "cpython-3.11.16+20260825-aarch64-apple-darwin-"
+                "install_only_stripped.tar.gz"
+            ),
+            url=(
+                "https://github.com/astral-sh/python-build-standalone/releases/download/"
+                "20260825/cpython-3.11.16%2B20260825-aarch64-apple-darwin-"
+                "install_only_stripped.tar.gz"
+            ),
+            sha256="a84adc050a29e0c7387c885ff13e6ac4b0027f9e841359e200d647313dbb5b03",
+        ),
+        archive_format="tar.gz",
+        archive_root="python",
+        python_relative_path="bin/python",
+    ),
+    "linux-x86_64": PythonBootstrap(
+        key="linux-x86_64",
+        asset=BootstrapAsset(
+            filename=(
+                "cpython-3.11.16+20260825-x86_64-unknown-linux-gnu-"
+                "install_only_stripped.tar.gz"
+            ),
+            url=(
+                "https://github.com/astral-sh/python-build-standalone/releases/download/"
+                "20260825/cpython-3.11.16%2B20260825-x86_64-unknown-linux-gnu-"
+                "install_only_stripped.tar.gz"
+            ),
+            sha256="232f75c9dd6733b41a8101b5076b2a248360722dedded5688f4ac7d5931d8eac",
+        ),
+        archive_format="tar.gz",
+        archive_root="python",
+        python_relative_path="bin/python",
+    ),
+}
+
+
+def supported_bootstrap_keys() -> tuple[str, ...]:
+    """返回发布管线明确支持的平台键。"""
+    return tuple(_BOOTSTRAPS)
+
+
+def bootstrap_for_key(key: str) -> PythonBootstrap:
+    """按发布平台键取固定引导契约。"""
+    try:
+        return _BOOTSTRAPS[key]
+    except KeyError as error:
+        raise RuntimeBootstrapError(
+            f"不支持的 Python 引导平台：{key}（可选：{', '.join(_BOOTSTRAPS)}）"
+        ) from error
+
+
+def current_bootstrap_key(*, system: str | None = None, machine: str | None = None) -> str:
+    """把当前系统与架构规范化为发布平台键。"""
+    system_name = (system or platform.system()).strip().casefold()
+    machine_name = (machine or platform.machine()).strip().casefold().replace("-", "_")
+    if machine_name in {"amd64", "x64"}:
+        machine_name = "x86_64"
+    elif machine_name == "aarch64":
+        machine_name = "arm64"
+
+    if system_name in {"windows", "win32"} and machine_name == "x86_64":
+        return "windows-x86_64"
+    if system_name in {"darwin", "macos"} and machine_name == "arm64":
+        return "macos-arm64"
+    if system_name == "linux" and machine_name == "x86_64":
+        return "linux-x86_64"
+    raise RuntimeBootstrapError(
+        f"当前平台没有可用的 Python 引导包：{system_name}/{machine_name}"
+    )
+
+
+def current_python_bootstrap() -> PythonBootstrap:
+    """取当前运行平台的 Python 引导契约。"""
+    return bootstrap_for_key(current_bootstrap_key())
+
+
+def asset_matches(path: Path, asset: BootstrapAsset) -> bool:
+    """流式校验引导资产，避免损坏文件进入构建或安装流程。"""
+    if not path.is_file():
+        return False
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return False
+    return digest.hexdigest() == asset.sha256
+
+
+def extract_python_bootstrap(
+    archive_path: Path,
+    target_dir: Path,
+    bootstrap: PythonBootstrap | None = None,
+) -> Path:
+    """安全解压平台 Python，返回可执行文件路径。"""
+    selected = bootstrap or current_python_bootstrap()
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    if target_dir.exists():
+        raise RuntimeBootstrapError(f"Python 引导目标已存在：{target_dir}")
+
+    try:
+        if selected.archive_format == "zip":
+            _extract_zip_safely(archive_path, target_dir)
+            _enable_embedded_site(target_dir)
+        elif selected.archive_format == "tar.gz":
+            _extract_tar_safely(archive_path, target_dir, selected.archive_root)
+        else:  # pragma: no cover - Literal + fixed registry guard this branch
+            raise RuntimeBootstrapError(f"不支持的 Python 归档格式：{selected.archive_format}")
+
+        python = target_dir / selected.python_relative_path
+        if not python.is_file():
+            raise RuntimeBootstrapError(f"Python 引导包缺少入口：{python}")
+        if os.name != "nt":
+            python.chmod(python.stat().st_mode | stat.S_IXUSR)
+        return python
+    except Exception:
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        raise
+
+
+def _safe_archive_name(name: str) -> PurePosixPath:
+    normalized = PurePosixPath(name.replace("\\", "/"))
+    if normalized.is_absolute() or not normalized.parts or ".." in normalized.parts:
+        raise RuntimeBootstrapError(f"Python 引导归档包含越界路径：{name}")
+    if normalized.parts[0].endswith(":"):
+        raise RuntimeBootstrapError(f"Python 引导归档包含绝对路径：{name}")
+    return normalized
+
+
+def _safe_link_name(name: str) -> PurePosixPath:
+    """链接允许合法的 ``..``，最终是否越界由解析后路径判断。"""
+    normalized = PurePosixPath(name.replace("\\", "/"))
+    if normalized.is_absolute() or not normalized.parts:
+        raise RuntimeBootstrapError(f"Python 引导归档包含绝对链接：{name}")
+    if normalized.parts[0].endswith(":"):
+        raise RuntimeBootstrapError(f"Python 引导归档包含绝对链接：{name}")
+    return normalized
+
+
+def _extract_zip_safely(archive_path: Path, target_dir: Path) -> None:
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            for item in archive.infolist():
+                _safe_archive_name(item.filename)
+            target_dir.mkdir(parents=True, exist_ok=False)
+            archive.extractall(target_dir)
+            for item in archive.infolist():
+                mode = (item.external_attr >> 16) & 0o777
+                extracted = target_dir.joinpath(*_safe_archive_name(item.filename).parts)
+                if mode and extracted.exists() and not extracted.is_symlink():
+                    extracted.chmod(mode)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise RuntimeBootstrapError(f"Python ZIP 解压失败：{error}") from error
+
+
+def _extract_tar_safely(archive_path: Path, target_dir: Path, archive_root: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="maw-python-bootstrap-") as temp_name:
+        temp_root = Path(temp_name).resolve()
+        try:
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                members = archive.getmembers()
+                for member in members:
+                    if not (
+                        member.isfile()
+                        or member.isdir()
+                        or member.issym()
+                        or member.islnk()
+                    ):
+                        raise RuntimeBootstrapError(
+                            f"Python 引导归档包含不支持的特殊文件：{member.name}"
+                        )
+                    member_path = _safe_archive_name(member.name)
+                    destination = (temp_root / Path(*member_path.parts)).resolve(strict=False)
+                    if destination != temp_root and temp_root not in destination.parents:
+                        raise RuntimeBootstrapError(
+                            f"Python 引导归档包含越界路径：{member.name}"
+                        )
+                    if member.issym() or member.islnk():
+                        link_name = _safe_link_name(member.linkname)
+                        link_base = destination.parent if member.issym() else temp_root
+                        link_target = (link_base / Path(*link_name.parts)).resolve(strict=False)
+                        if link_target != temp_root and temp_root not in link_target.parents:
+                            raise RuntimeBootstrapError(
+                                f"Python 引导归档包含越界链接：{member.name}"
+                            )
+                archive.extractall(temp_root)
+        except (OSError, tarfile.TarError) as error:
+            raise RuntimeBootstrapError(f"Python tar 解压失败：{error}") from error
+
+        source = temp_root.joinpath(*_safe_archive_name(archive_root).parts)
+        if not source.is_dir():
+            raise RuntimeBootstrapError(f"Python 引导归档缺少根目录：{archive_root}")
+        shutil.copytree(source, target_dir, symlinks=True)
+
+
+def _enable_embedded_site(target_dir: Path) -> None:
+    pth_files = sorted(target_dir.glob("python*._pth"))
+    if not pth_files:
+        return
+    pth_path = pth_files[0]
+    text = pth_path.read_text(encoding="utf-8")
+    text = text.replace("#import site", "import site")
+    if "../site-packages" not in text:
+        text = text.rstrip() + "\n../site-packages\n"
+    pth_path.write_text(text, encoding="utf-8", newline="\n")
+
+
+__all__ = [
+    "BootstrapAsset",
+    "GET_PIP_ASSET",
+    "PythonBootstrap",
+    "RuntimeBootstrapError",
+    "asset_matches",
+    "bootstrap_for_key",
+    "current_bootstrap_key",
+    "current_python_bootstrap",
+    "extract_python_bootstrap",
+    "supported_bootstrap_keys",
+]

--- a/maw/runtimes/base.py
+++ b/maw/runtimes/base.py
@@ -22,7 +22,6 @@ import shutil
 import subprocess
 import sys
 import threading
-import zipfile
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,9 +41,16 @@ from maw.runtime_manifest import (
     read_runtime_manifest,
     write_runtime_manifest,
 )
+from maw.runtime_bootstrap import (
+    BootstrapAsset,
+    GET_PIP_ASSET,
+    asset_matches,
+    current_python_bootstrap,
+    extract_python_bootstrap,
+)
 from maw.runtime_mirror_picker import pick_fastest_mirror
 
-GET_PIP_SCRIPT: Final = "get-pip.py"
+GET_PIP_SCRIPT: Final = GET_PIP_ASSET.filename
 
 RuntimeEvent = Callable[[str, int, str], None]
 RuntimeLine = Callable[[str], None]
@@ -67,8 +73,8 @@ class RuntimeSpec:
 
     字段按用途分组：
     - 身份：key / runtime_version / python_version
-    - 安装资产与依赖：embed_python_zip / requirements_key（frozen txt 的
-      pyproject extra 名）/ requirements_bundle_name / requirements（moss
+    - 安装资产与依赖：requirements_key（frozen txt 的 pyproject
+      extra 名）/ requirements_bundle_name / requirements（moss
       迁移期的手写列表，之后删除）/ extra_index_url / cuda_fallback_packages
     - 进度与文案：requirements_emit / ready_emit_done / missing_detail /
       ready_detail / message_prefix / feature_label / fix_action_label
@@ -84,7 +90,6 @@ class RuntimeSpec:
     key: str
     runtime_version: str
     python_version: str
-    embed_python_zip: str
     requirements_emit: str
     requirements_key: str
     requirements_bundle_name: str
@@ -211,8 +216,8 @@ class ManagedRuntime:
 
     def python_path(self, root: str | Path | None = None) -> Path:
         target = self.resolve_root(root) if root is None else Path(root)
-        relative = Path("python") / "python.exe" if os.name == "nt" else Path("python") / "bin" / "python"
-        return target / relative
+        bootstrap = current_python_bootstrap()
+        return target / "python" / bootstrap.python_relative_path
 
     def site_packages(self, root: str | Path | None = None) -> Path:
         target = self.resolve_root(root) if root is None else Path(root)
@@ -372,11 +377,15 @@ class ManagedRuntime:
             raise self._error(f"{spec.message_prefix}路径不能是一个文件：{root}")
         root.parent.mkdir(parents=True, exist_ok=True)
 
-        embed_zip = _find_bootstrap_asset(spec.embed_python_zip)
-        get_pip = _find_bootstrap_asset(GET_PIP_SCRIPT)
-        if embed_zip is None or get_pip is None:
+        bootstrap = current_python_bootstrap()
+        python_archive = _find_bootstrap_asset(
+            bootstrap.asset.filename, expected=bootstrap.asset
+        )
+        get_pip = _find_bootstrap_asset(GET_PIP_SCRIPT, expected=GET_PIP_ASSET)
+        if python_archive is None or get_pip is None:
             raise self._error(
-                f"未找到{spec.feature_label}安装资产（embedded Python 或 get-pip.py）。"
+                f"未找到或无法校验{spec.feature_label}安装资产"
+                f"（{bootstrap.key} embedded Python 或 get-pip.py）。"
                 "请使用官方打包版。"
             )
 
@@ -401,7 +410,7 @@ class ManagedRuntime:
         if repair or not python.exists():
             if python_dir.exists():
                 shutil.rmtree(python_dir)
-            _extract_embed_python(embed_zip, python_dir)
+            _extract_embed_python(python_archive, python_dir)
         _may_cancel(cancel, spec)
         if not python.exists():
             raise self._error(f"{spec.message_prefix}解压失败：未找到 {python}")
@@ -524,40 +533,32 @@ class ManagedRuntime:
 # ---------------------------------------------------------------------------
 
 
-def _find_bootstrap_asset(filename: str) -> Path | None:
-    """在 bundle / exe 邻目录 / 源码 build/ 里找安装资产（embedded zip、get-pip.py）。"""
+def _find_bootstrap_asset(
+    filename: str,
+    *,
+    expected: BootstrapAsset | None = None,
+) -> Path | None:
+    """在 bundle / exe 邻目录 / 源码 build/ 中查找并校验引导资产。"""
     candidates: list[Path] = [
         asset_path(f"bootstrap/{filename}"),
         Path(sys.executable).resolve().parent / "bootstrap" / filename,
     ]
     if not getattr(sys, "frozen", False):
-        candidates.append(Path(__file__).resolve().parents[2] / "build" / filename)
+        build_root = Path(__file__).resolve().parents[2] / "build"
+        candidates.extend((build_root / "bootstrap" / filename, build_root / filename))
     for candidate in candidates:
-        if candidate.is_file():
+        if candidate.is_file() and (expected is None or asset_matches(candidate, expected)):
             return candidate.resolve()
     return None
 
 
-def _extract_embed_python(zip_path: Path, target_dir: Path) -> None:
-    """解压 embedded Python 并打开 site + target 支持（改 python*._pth）。"""
-    target_dir.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(zip_path) as archive:
-        archive.extractall(target_dir)
-    pth_files = sorted(target_dir.glob("python*._pth"))
-    if not pth_files:
-        return
-    pth_path = pth_files[0]
-    text = pth_path.read_text(encoding="utf-8")
-    text = text.replace("#import site", "import site")
-    # 嵌入版 Python 的 _pth 控制 sys.path 且忽略 PYTHONPATH；把 pip --target
-    # 安装目录 ../site-packages 加进去。
-    if "../site-packages" not in text:
-        text = text.rstrip() + "\n../site-packages\n"
-    pth_path.write_text(text, encoding="utf-8", newline="\n")
+def _extract_embed_python(archive_path: Path, target_dir: Path) -> None:
+    """兼容旧内部名称；实际按当前平台解压 ZIP 或 tar 归档。"""
+    extract_python_bootstrap(archive_path, target_dir)
 
 
 def _get_pip_command(python_exe: Path, get_pip_path: Path) -> list[str]:
-    """Build the command to bootstrap pip into an embedded Python."""
+    """Build the command to bootstrap pip into a managed Python."""
     return [str(python_exe), str(get_pip_path)]
 
 

--- a/maw/runtimes/local_spec.py
+++ b/maw/runtimes/local_spec.py
@@ -7,7 +7,6 @@ from maw.runtimes.base import ManagedRuntimeError, RuntimeCancelled, RuntimeSpec
 RUNTIME_VERSION = "5"
 PYTHON_VERSION = "3.11"
 PYTORCH_INDEX = "https://download.pytorch.org/whl/cu130"
-EMBED_PYTHON_ZIP = "python-3.11.9-embed-amd64.zip"
 
 _VERIFY_COMMAND = (
     "from funasr import AutoModel; from qwen_asr import Qwen3ASRModel; "
@@ -27,7 +26,6 @@ LOCAL_SPEC = RuntimeSpec(
     key="local",
     runtime_version=RUNTIME_VERSION,
     python_version=PYTHON_VERSION,
-    embed_python_zip=EMBED_PYTHON_ZIP,
     requirements_emit="正在安装本地 ASR 依赖（Torch、FunASR、QwenASR）……",
     requirements_key="local",
     requirements_bundle_name="requirements-local.txt",

--- a/maw/runtimes/moss_spec.py
+++ b/maw/runtimes/moss_spec.py
@@ -2,8 +2,8 @@
 
 MOSS Transcribe-Diarize 依赖 Transformers 5.x，与本地 QwenASR / FunASR
 （funasr / Transformers 4.x 侧）不能共享同一个环境，因此独立安装到
-``local-runtime-moss``（Python 3.11，与 local 共用同一个 embedded zip，
-避免 bundle 额外携带 3.12）。依赖声明于仓库根 ``moss-requirements.in``
+``local-runtime-moss``（Python 3.11，与 local 共用当前平台的 Python
+引导包）。依赖声明于仓库根 ``moss-requirements.in``
 （与 local/ocr 的 pyproject extra 同一「单一真源」机制；因 Transformers
 与 qwen-asr 互斥无法共容于 uv.lock，故独立声明、独立冻结），构建期由
 ``uv pip compile`` 生成 ``requirements-moss.txt``。
@@ -40,7 +40,6 @@ MOSS_SPEC = RuntimeSpec(
     key="moss",
     runtime_version=MOSS_RUNTIME_VERSION,
     python_version=MOSS_PYTHON_VERSION,
-    embed_python_zip="python-3.11.9-embed-amd64.zip",
     requirements_emit="正在安装 MOSS 本地依赖（Transformers 5.x、Torch）……",
     requirements_key="moss",
     requirements_bundle_name="requirements-moss.txt",

--- a/maw/runtimes/ocr_spec.py
+++ b/maw/runtimes/ocr_spec.py
@@ -40,7 +40,6 @@ OCR_SPEC = RuntimeSpec(
     key="ocr",
     runtime_version=OCR_RUNTIME_VERSION,
     python_version=OCR_PYTHON_VERSION,
-    embed_python_zip="python-3.11.9-embed-amd64.zip",
     requirements_emit="正在安装 OCR 模型和依赖……",
     requirements_key="ocr",
     requirements_bundle_name="requirements-ocr.txt",

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -15,6 +15,8 @@ mkdir -p "$BUILD_DIR"
 echo "==> 1/6 PyInstaller 构建 dist/MAW"
 # 生成托管 Runtime 的 frozen requirements txt（MAW.spec datas 条件追加打包）。
 mkdir -p build
+uv run python scripts/prepare_runtime_bootstrap.py --platform linux-x86_64
+uv run python scripts/smoke_runtime_bootstrap.py --platform linux-x86_64
 uv export --frozen --extra local --no-dev --format requirements-txt -o build/requirements-local.txt
 uv export --frozen --extra ocr --no-dev --format requirements-txt -o build/requirements-ocr.txt
 # moss 依赖与 local（qwen-asr/Transformers 4.x）互斥，独立声明、独立冻结。

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -19,6 +19,8 @@ if (-not (Test-Path -LiteralPath $EntryPoint -PathType Leaf)) {
 Push-Location -LiteralPath $RepoRoot
 try {
     uv sync --group build --frozen
+    uv run python scripts\prepare_runtime_bootstrap.py --platform windows-x86_64
+    uv run python scripts\smoke_runtime_bootstrap.py --platform windows-x86_64
     # 生成托管 Runtime 的 frozen requirements txt（MAW.spec datas 条件追加打包）。
     New-Item -ItemType Directory -Path 'build' -Force | Out-Null
     uv export --frozen --extra local --no-dev --format requirements-txt -o build/requirements-local.txt
@@ -43,17 +45,6 @@ try {
     Copy-Item -LiteralPath $FaqSource -Destination $FaqBundlePath -Force
     if (-not (Test-Path -LiteralPath $FaqBundlePath -PathType Leaf)) {
         throw "Build completed but did not copy FAQ-常见问题.txt beside MAW.exe."
-    }
-
-    $BootstrapDirectory = Join-Path (Split-Path -Parent $ExePath) 'bootstrap'
-    New-Item -ItemType Directory -Path $BootstrapDirectory -Force | Out-Null
-    $EmbedZip = Join-Path $RepoRoot 'build' 'python-3.11.9-embed-amd64.zip'
-    $GetPip = Join-Path $RepoRoot 'build' 'get-pip.py'
-    foreach ($Asset in @($EmbedZip, $GetPip)) {
-        if (-not (Test-Path -LiteralPath $Asset -PathType Leaf)) {
-            throw "Missing bootstrap asset: $Asset"
-        }
-        Copy-Item -LiteralPath $Asset -Destination (Join-Path $BootstrapDirectory (Split-Path -Leaf $Asset)) -Force
     }
 
     Write-Host "Built $ExePath"

--- a/scripts/prepare_runtime_bootstrap.py
+++ b/scripts/prepare_runtime_bootstrap.py
@@ -1,0 +1,76 @@
+"""下载并校验当前发布平台的 Python 引导资产。"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from maw.runtime_bootstrap import (  # noqa: E402
+    BootstrapAsset,
+    GET_PIP_ASSET,
+    asset_matches,
+    bootstrap_for_key,
+    current_bootstrap_key,
+    supported_bootstrap_keys,
+)
+
+DEFAULT_OUTPUT = ROOT / "build" / "bootstrap"
+
+
+def prepare_asset(asset: BootstrapAsset, output_dir: Path, *, attempts: int = 3) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / asset.filename
+    if asset_matches(target, asset):
+        print(f"已验证：{target}")
+        return target
+    if target.exists():
+        target.unlink()
+
+    partial = target.with_name(target.name + ".part")
+    if partial.exists():
+        partial.unlink()
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            request = urllib.request.Request(asset.url, headers={"User-Agent": "MAW-runtime-bootstrap/1"})
+            with urllib.request.urlopen(request, timeout=300) as response, partial.open("wb") as output:
+                while chunk := response.read(1024 * 1024):
+                    output.write(chunk)
+            if not asset_matches(partial, asset):
+                raise ValueError(
+                    f"SHA-256 不匹配：{asset.filename}\n期望 {asset.sha256}"
+                )
+            os.replace(partial, target)
+            print(f"已准备：{target}")
+            return target
+        except (OSError, ValueError) as error:
+            last_error = error
+            if partial.exists():
+                partial.unlink()
+            if attempt < attempts:
+                time.sleep(attempt)
+    raise SystemExit(f"无法准备引导资产 {asset.filename}：{last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="准备 MAW 跨平台 Python 引导资产")
+    parser.add_argument("--platform", choices=supported_bootstrap_keys(), default=current_bootstrap_key())
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    bootstrap = bootstrap_for_key(args.platform)
+    prepare_asset(bootstrap.asset, args.output)
+    prepare_asset(GET_PIP_ASSET, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_runtime_bootstrap.py
+++ b/scripts/smoke_runtime_bootstrap.py
@@ -1,0 +1,58 @@
+"""用真实归档冒烟验证 Python 解压、启动与 pip 引导。"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from maw.runtime_bootstrap import (  # noqa: E402
+    GET_PIP_ASSET,
+    asset_matches,
+    bootstrap_for_key,
+    current_bootstrap_key,
+    extract_python_bootstrap,
+    supported_bootstrap_keys,
+)
+
+DEFAULT_ASSET_DIR = ROOT / "build" / "bootstrap"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="冒烟验证 MAW Python 引导资产")
+    parser.add_argument("--platform", choices=supported_bootstrap_keys(), default=current_bootstrap_key())
+    parser.add_argument("--asset-dir", type=Path, default=DEFAULT_ASSET_DIR)
+    args = parser.parse_args()
+
+    bootstrap = bootstrap_for_key(args.platform)
+    archive = args.asset_dir / bootstrap.asset.filename
+    get_pip = args.asset_dir / GET_PIP_ASSET.filename
+    if not asset_matches(archive, bootstrap.asset) or not asset_matches(
+        get_pip, GET_PIP_ASSET
+    ):
+        raise SystemExit("引导资产缺失或校验失败，请先运行 prepare_runtime_bootstrap.py。")
+
+    environment = dict(os.environ)
+    environment.update({"PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"})
+    with tempfile.TemporaryDirectory(prefix="maw-bootstrap-smoke-") as temp_name:
+        python = extract_python_bootstrap(archive, Path(temp_name) / "python", bootstrap)
+        subprocess.run([str(python), "--version"], check=True, env=environment)
+        subprocess.run(
+            [str(python), str(get_pip), "--disable-pip-version-check"],
+            check=True,
+            env=environment,
+        )
+        subprocess.run([str(python), "-m", "pip", "--version"], check=True, env=environment)
+    print(f"引导冒烟验证通过：{bootstrap.key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -370,6 +370,7 @@ class PackagingContractTests(unittest.TestCase):
         windows = read_text("scripts/build-windows.ps1")
         appimage = read_text("scripts/build-appimage.sh")
         release = read_text(".github/workflows/release.yml")
+        lint = read_text(".github/workflows/python-lint.yml")
 
         for key in ("windows-x86_64", "macos-arm64", "linux-x86_64"):
             self.assertIn(f'"{key}"', registry)
@@ -392,6 +393,10 @@ class PackagingContractTests(unittest.TestCase):
         self.assertIn("smoke_runtime_bootstrap.py --platform linux-x86_64", appimage)
         self.assertIn("Contents/Resources/bootstrap/cpython-3.11.16", release)
         self.assertIn("_internal/bootstrap/cpython-3.11.16", release)
+        self.assertIn("Runtime bootstrap smoke (${{ matrix.name }})", lint)
+        self.assertIn("platform: macos-arm64", lint)
+        self.assertIn("platform: linux-x86_64", lint)
+        self.assertIn("smoke_runtime_bootstrap.py --platform ${{ matrix.platform }}", lint)
 
     def test_release_workflow_is_tag_triggered_and_publishes_both_windows_packages(self) -> None:
         """Given a v* tag push, When workflow is read, Then it releases MAW and MAW-lite builds."""

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -345,8 +345,8 @@ class PackagingContractTests(unittest.TestCase):
         self.assertNotIn("desktop", script)
         self.assertNotIn("MOSE", script)
         self.assertIn("bootstrap", script)
-        self.assertIn("python-3.11.9-embed-amd64.zip", script)
-        self.assertIn("get-pip.py", script)
+        self.assertIn("prepare_runtime_bootstrap.py --platform windows-x86_64", script)
+        self.assertIn("smoke_runtime_bootstrap.py --platform windows-x86_64", script)
         self.assertIn("$ErrorActionPreference = 'Stop'", script)
 
     def test_windows_preview_workflow_verifies_launcher_version(self) -> None:
@@ -355,22 +355,43 @@ class PackagingContractTests(unittest.TestCase):
 
         self.assertIn("scripts/sync_launcher_version.py --check", workflow)
 
-    def test_windows_preview_workflow_downloads_bootstrap_assets_before_build(self) -> None:
-        """Given a clean checkout, When the preview builds, Then bootstrap assets exist before PyInstaller runs."""
+    def test_windows_preview_workflow_verifies_bundled_bootstrap_assets(self) -> None:
+        """Given a clean checkout, When preview packaging completes, Then Windows bootstrap assets are present."""
         workflow = read_text(".github/workflows/pr-release-windows.yml")
 
-        self.assertIn("Download embedded Python bootstrap assets", workflow)
-        self.assertIn(
-            "https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip",
-            workflow,
-        )
-        self.assertIn("https://bootstrap.pypa.io/get-pip.py", workflow)
         self.assertIn("build-windows.ps1 -SkipTests", workflow)
-        self.assertLess(
-            workflow.index("python-3.11.9-embed-amd64.zip"),
-            workflow.index("build-windows.ps1 -SkipTests"),
-            "bootstrap 下载步骤必须在调用 build-windows.ps1 之前",
-        )
+        self.assertIn(r"_internal\bootstrap\python-3.11.9-embed-amd64.zip", workflow)
+        self.assertIn(r"_internal\bootstrap\get-pip.py", workflow)
+
+    def test_cross_platform_runtime_bootstrap_is_pinned_and_built_everywhere(self) -> None:
+        """Given three release platforms, When packages are built, Then one pinned registry drives every bootstrap."""
+        registry = read_text("maw/runtime_bootstrap.py")
+        spec = read_text("MAW.spec")
+        windows = read_text("scripts/build-windows.ps1")
+        appimage = read_text("scripts/build-appimage.sh")
+        release = read_text(".github/workflows/release.yml")
+
+        for key in ("windows-x86_64", "macos-arm64", "linux-x86_64"):
+            self.assertIn(f'"{key}"', registry)
+        for digest in (
+            "009d6bf7e3b2ddca3d784fa09f90fe54336d5b60f0e0f305c37f400bf83cfd3b",
+            "a84adc050a29e0c7387c885ff13e6ac4b0027f9e841359e200d647313dbb5b03",
+            "232f75c9dd6733b41a8101b5076b2a248360722dedded5688f4ac7d5931d8eac",
+            "fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6",
+        ):
+            self.assertIn(digest, registry)
+        self.assertIn("current_python_bootstrap()", spec)
+        self.assertIn("asset_matches(_bootstrap_path, _bootstrap_asset)", spec)
+        self.assertIn('datas.append((str(_bootstrap_path), "bootstrap"))', spec)
+        self.assertIn("Missing or invalid runtime bootstrap asset", spec)
+        self.assertIn("prepare_runtime_bootstrap.py --platform windows-x86_64", windows)
+        self.assertIn("smoke_runtime_bootstrap.py --platform windows-x86_64", windows)
+        self.assertIn("prepare_runtime_bootstrap.py --platform macos-arm64", release)
+        self.assertIn("smoke_runtime_bootstrap.py --platform macos-arm64", release)
+        self.assertIn("prepare_runtime_bootstrap.py --platform linux-x86_64", appimage)
+        self.assertIn("smoke_runtime_bootstrap.py --platform linux-x86_64", appimage)
+        self.assertIn("Contents/Resources/bootstrap/cpython-3.11.16", release)
+        self.assertIn("_internal/bootstrap/cpython-3.11.16", release)
 
     def test_release_workflow_is_tag_triggered_and_publishes_both_windows_packages(self) -> None:
         """Given a v* tag push, When workflow is read, Then it releases MAW and MAW-lite builds."""

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import io
+import os
+import stat
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from maw.runtime_bootstrap import (
+    GET_PIP_ASSET,
+    RuntimeBootstrapError,
+    asset_matches,
+    bootstrap_for_key,
+    current_bootstrap_key,
+    extract_python_bootstrap,
+    supported_bootstrap_keys,
+)
+
+
+class RuntimeBootstrapRegistryTests(unittest.TestCase):
+    def test_supported_release_platforms_have_pinned_assets(self) -> None:
+        self.assertEqual(
+            supported_bootstrap_keys(),
+            ("windows-x86_64", "macos-arm64", "linux-x86_64"),
+        )
+        for key in supported_bootstrap_keys():
+            bootstrap = bootstrap_for_key(key)
+            self.assertEqual(len(bootstrap.asset.sha256), 64)
+            self.assertTrue(bootstrap.asset.url.startswith("https://"))
+            self.assertIn(bootstrap.archive_format, {"zip", "tar.gz"})
+            self.assertTrue(bootstrap.python_relative_path)
+        self.assertEqual(len(GET_PIP_ASSET.sha256), 64)
+        self.assertIn("f6f644156f23dfe9acc06e7b9ca75eee311f2e37", GET_PIP_ASSET.url)
+
+    def test_platform_aliases_map_to_release_keys(self) -> None:
+        self.assertEqual(
+            current_bootstrap_key(system="Windows", machine="AMD64"),
+            "windows-x86_64",
+        )
+        self.assertEqual(
+            current_bootstrap_key(system="Darwin", machine="aarch64"),
+            "macos-arm64",
+        )
+        self.assertEqual(
+            current_bootstrap_key(system="Linux", machine="x86_64"),
+            "linux-x86_64",
+        )
+
+    def test_unsupported_platform_is_actionable(self) -> None:
+        with self.assertRaisesRegex(RuntimeBootstrapError, "linux/arm64"):
+            current_bootstrap_key(system="Linux", machine="arm64")
+
+    def test_asset_checksum_rejects_missing_and_corrupt_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_name:
+            path = Path(temp_name) / "get-pip.py"
+            self.assertFalse(asset_matches(path, GET_PIP_ASSET))
+            path.write_bytes(b"corrupt")
+            self.assertFalse(asset_matches(path, GET_PIP_ASSET))
+
+
+class RuntimeBootstrapExtractionTests(unittest.TestCase):
+    def test_windows_zip_enables_site_and_target_packages(self) -> None:
+        bootstrap = bootstrap_for_key("windows-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "python.zip"
+            with zipfile.ZipFile(archive, mode="w") as bundle:
+                bundle.writestr("python.exe", b"python")
+                bundle.writestr("python311._pth", "python311.zip\n.\n#import site\n")
+
+            python = extract_python_bootstrap(archive, root / "runtime", bootstrap)
+
+            self.assertEqual(python, root / "runtime" / "python.exe")
+            pth = (root / "runtime" / "python311._pth").read_text(encoding="utf-8")
+            self.assertIn("import site", pth)
+            self.assertIn("../site-packages", pth)
+
+    def test_tar_preserves_python_symlink_and_executable_mode(self) -> None:
+        bootstrap = bootstrap_for_key("macos-arm64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            payload = root / "payload" / "python" / "bin"
+            payload.mkdir(parents=True)
+            executable = payload / "python3.11"
+            executable.write_bytes(b"python")
+            executable.chmod(0o755)
+            (payload / "python").symlink_to("python3.11")
+            archive = root / "python.tar.gz"
+            with tarfile.open(archive, mode="w:gz") as bundle:
+                bundle.add(root / "payload" / "python", arcname="python")
+
+            python = extract_python_bootstrap(archive, root / "runtime", bootstrap)
+
+            self.assertTrue(python.is_symlink())
+            self.assertEqual(os.readlink(python), "python3.11")
+            self.assertTrue(python.stat().st_mode & stat.S_IXUSR)
+
+    def test_tar_allows_internal_parent_relative_symlink(self) -> None:
+        bootstrap = bootstrap_for_key("linux-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "python.tar.gz"
+            with tarfile.open(archive, mode="w:gz") as bundle:
+                for directory_name in ("python", "python/bin", "python/lib"):
+                    directory = tarfile.TarInfo(directory_name)
+                    directory.type = tarfile.DIRTYPE
+                    directory.mode = 0o755
+                    bundle.addfile(directory)
+                payload = tarfile.TarInfo("python/lib/python3.11")
+                payload.mode = 0o755
+                payload.size = 6
+                bundle.addfile(payload, io.BytesIO(b"python"))
+                link = tarfile.TarInfo("python/bin/python")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "../lib/python3.11"
+                bundle.addfile(link)
+
+            python = extract_python_bootstrap(archive, root / "runtime", bootstrap)
+
+            self.assertTrue(python.is_symlink())
+            self.assertEqual(os.readlink(python), "../lib/python3.11")
+            self.assertTrue(python.resolve().is_file())
+
+    def test_zip_path_traversal_is_rejected_without_partial_runtime(self) -> None:
+        bootstrap = bootstrap_for_key("windows-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "bad.zip"
+            with zipfile.ZipFile(archive, mode="w") as bundle:
+                bundle.writestr("../escape", b"bad")
+
+            target = root / "runtime"
+            with self.assertRaisesRegex(RuntimeBootstrapError, "越界路径"):
+                extract_python_bootstrap(archive, target, bootstrap)
+            self.assertFalse(target.exists())
+            self.assertFalse((root / "escape").exists())
+
+    def test_archive_without_python_entry_leaves_no_partial_runtime(self) -> None:
+        bootstrap = bootstrap_for_key("windows-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "incomplete.zip"
+            with zipfile.ZipFile(archive, mode="w") as bundle:
+                bundle.writestr("python311.zip", b"incomplete")
+
+            target = root / "runtime"
+            with self.assertRaisesRegex(RuntimeBootstrapError, "缺少入口"):
+                extract_python_bootstrap(archive, target, bootstrap)
+            self.assertFalse(target.exists())
+
+    def test_tar_link_traversal_is_rejected_without_partial_runtime(self) -> None:
+        bootstrap = bootstrap_for_key("linux-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "bad.tar.gz"
+            with tarfile.open(archive, mode="w:gz") as bundle:
+                directory = tarfile.TarInfo("python/bin")
+                directory.type = tarfile.DIRTYPE
+                bundle.addfile(directory)
+                link = tarfile.TarInfo("python/bin/python")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "../../../escape"
+                bundle.addfile(link)
+                payload = tarfile.TarInfo("python/bin/python3.11")
+                payload.size = 6
+                bundle.addfile(payload, io.BytesIO(b"python"))
+
+            target = root / "runtime"
+            with self.assertRaisesRegex(RuntimeBootstrapError, "越界链接"):
+                extract_python_bootstrap(archive, target, bootstrap)
+            self.assertFalse(target.exists())
+            self.assertFalse((root / "escape").exists())
+
+    def test_tar_special_file_is_rejected_without_partial_runtime(self) -> None:
+        bootstrap = bootstrap_for_key("linux-x86_64")
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = Path(temp_name)
+            archive = root / "bad.tar.gz"
+            with tarfile.open(archive, mode="w:gz") as bundle:
+                fifo = tarfile.TarInfo("python/unsafe-pipe")
+                fifo.type = tarfile.FIFOTYPE
+                bundle.addfile(fifo)
+
+            target = root / "runtime"
+            with self.assertRaisesRegex(RuntimeBootstrapError, "特殊文件"):
+                extract_python_bootstrap(archive, target, bootstrap)
+            self.assertFalse(target.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

修复 Runtime 抽象合并后，macOS/Linux 官方产物仍无法正确创建本地 ASR、OCR 和 MOSS 运行环境的问题。此前三平台共用 Windows 嵌入式 Python 文件名，但 macOS/Linux 构建没有携带匹配平台的引导资产。

## 主要内容

- 新增三平台统一引导注册表，集中固定归档名、下载地址、SHA-256、归档格式和 Python 入口。
- Windows x64 保留官方 Python 3.11.9 embeddable ZIP；macOS arm64、Linux x86_64 改用固定版本的 python-build-standalone 归档。
- 下载、构建和用户安装阶段均校验 SHA-256，错误资产不会进入安装包或运行环境。
- ZIP/tar 解压增加路径越界、链接越界和特殊文件防护，并保留 Unix 执行权限及内部链接。
- Windows Preview/Release、macOS Release 和 Linux AppImage 构建统一执行资源准备、真实 pip 引导冒烟及产物存在性检查。
- PR 检查新增 macOS arm64 与 Linux x86_64 引导冒烟矩阵，后续跨平台问题可在合并前发现。
- 更新第三方组件说明及打包契约测试。

## 验证

- 全量 Python 测试：779 项通过，5 项条件跳过。
- Ruff、GitHub Actions YAML 解析、AppImage shell 语法和 git diff 检查通过。
- macOS arm64：真实归档解压、Python 3.11.16 启动、pip 安装、MAW.app 打包及启动通过。
- Windows x64：真实归档 SHA-256、解压结构和 _pth 配置检查通过。
- 定向 Runtime/打包契约测试：31 项通过。

## 验证边界

- Windows 可执行启动及 Linux 完整解压/启动由本 PR 对应 GitHub Actions 继续验证。
- 未修改模型、推理流程、用户数据、运行环境状态协议或 CPU/CUDA 选择逻辑。