### PR TITLE
fix(launcher): friendly error messages update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,12 @@
 - **MAW 用户数据路径统一** ： 普通日志、启动诊断日志、Linux Emoji 字体缓存和 server-editor 设置统一使用 MAW 用户数据根；Windows 默认根目录为 `%LOCALAPPDATA%\MAW`，原 server-editor 设置路径仅在新文件不存在时作为升级读取回退，后续保存始终写入新路径。Release 版 `.env` 优先读取应用程序同目录文件，不存在时回退到 `%LOCALAPPDATA%\MAW\.env`；源码开发继续使用仓库根 `.env`。
 - **腾讯云 Launcher 入口** ： API Key 链接改为 TokenHub 密钥管理页面，并暂时从供应商下拉列表隐藏「腾讯云录音文件识别」；底层 CLI 与配置能力保留。
 
+### 🐛 修复
+
+- **后处理与工具箱报错友好化** ： Launcher 前端新增 12 个错误码的中英文翻译（`postprocess_connection_failed`、`postprocess_models_failed`、`batch_items_*`、`mose_*`、`alignment_*`、`invalid_reasoning_mode` 等），覆盖 LLM 连接/模型获取、批量任务、MOSE 编辑器、口播对齐等场景；所有用户可见错误均通过红框错误卡片展示操作指引，不阻断底部状态栏，后端日志保持英文便于排查。
+
+- **批处理诊断补全** ： 混合队列逐项失败保留错误码并使用统一的友好提示；启动错误日志、本地事件日志和错误报告覆盖常见 API Key、Secret、Token、Password 与 Bearer 凭据格式的脱敏。
+
 ## [1.5.0-beta.9] - 2026-08-29
 
 ### ✨ 提升

--- a/maw/gui_web.py
+++ b/maw/gui_web.py
@@ -13,7 +13,7 @@ import threading
 import tempfile
 import time
 import webbrowser
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -29,7 +29,7 @@ from maw.gui_config import DEFAULT_ENV_PATH, DEFAULT_MODEL_ID, MODELS, PROVIDERS
 from maw.gui_platform import apply_dark_title_bar, asset_path, creationflags, popen_process_tree, process_group_kwargs, release_process_tree, startupinfo, terminate_process_tree
 from maw.gui_workflow import TranscriptionCancelledError, TranscriptionProcessError, TranscriptionRequest, TranscriptionResult, _bundled_ffmpeg_directory, _child_environment, _ffmpeg_search_path, build_alignment_serve_command, build_serve_command, default_srt_path, raw_response_path, run_transcription, unique_output_path, with_test_suffix
 from maw.launcher_batch import BatchItem, run_batch
-from maw.local_log import LocalLogSink, TeeWriter, default_log_directory, install_stdio_tee
+from maw.local_log import LocalLogSink, TeeWriter, default_log_directory, install_stdio_tee, redact_sensitive_text
 from maw.local_runtime import (
     LocalRuntimeCancelled,
     LocalRuntimeError,
@@ -86,6 +86,8 @@ MOSE_REGISTRY_KEY = r"Software\Moy\MOSE"
 MOSE_FILE_TYPE = "Moy.MOSE.Project"
 # 服务端先监听再在后台准备工程；这里的窗口只负责兜底探测进程是否已响应。
 SERVER_START_TIMEOUT: Final = 30.0
+SERVER_DIAGNOSTIC_LOG_LINES: Final = 12
+SERVER_DIAGNOSTIC_LOG_CHARS: Final = 2000
 # Keep this aligned with pyproject.toml; release workflows synchronize and verify it.
 BUNDLED_APP_VERSION = "1.5.3"
 MOSE_VERSION = "0.1.0"
@@ -1389,8 +1391,11 @@ class LauncherApi:
                 detail = f"{url} | 进程退出码 {exit_code}" + (f"：{detail}" if detail else "")
                 _ = self._stop_owned_server()
                 return _error_result("port", "server_start_failed", detail)
+            diagnostics = self._server_no_response_diagnostics(url)
             _ = self._stop_owned_server()
-            return _error_result("port", "server_no_response", url)
+            result = _error_result("port", "server_no_response", url)
+            result["diagnostics"] = diagnostics
+            return result
         self._close_server_log()
         return {"ok": True, "url": launch_url}
 
@@ -1584,6 +1589,23 @@ class LauncherApi:
         except (OSError, ValueError):
             return ""
 
+    def _server_no_response_diagnostics(self, url: str) -> dict[str, object]:
+        """Collect bounded diagnostics while the still-running child is observable."""
+        diagnostics: dict[str, object] = {"processState": "running"}
+        process = self.server_process
+        pid = getattr(process, "pid", None)
+        if isinstance(pid, int) and pid > 0:
+            diagnostics["pid"] = pid
+
+        _ready, probe_detail = _probe_server(url)
+        if probe_detail:
+            diagnostics["lastProbe"] = probe_detail
+
+        log_tail = _diagnostic_tail(self._read_server_log())
+        if log_tail:
+            diagnostics["startupLogTail"] = log_tail
+        return diagnostics
+
     def _close_server_log(self) -> None:
         log_file = self.server_log_file
         self.server_log_file = None
@@ -1723,9 +1745,9 @@ class LauncherApi:
                 items.append(BatchItem(str(raw_item.get("id") or index), replace(request, srt_path=selected)))
                 reserved.update(_artifact_paths(selected))
             except PreflightError as error:
-                items.append(BatchItem(item_id, None, error.message))
+                items.append(BatchItem(item_id, None, error.message, error.code))
             except (OSError, ValueError) as error:
-                items.append(BatchItem(item_id, None, str(error)))
+                items.append(BatchItem(item_id, None, str(error), "batch_item_invalid"))
         manifest_text = str(payload.get("manifestPath") or "").strip()
         first_request = next((item.request for item in items if item.request is not None), None)
         if first_request is None:
@@ -2986,15 +3008,46 @@ def _drop_paths_from_event(event: Mapping[str, object]) -> list[str]:
     return paths
 
 
+def _diagnostic_tail(value: str) -> str:
+    text = redact_sensitive_text(value).strip()
+    if not text:
+        return ""
+    lines = text.splitlines()
+    if len(lines) > SERVER_DIAGNOSTIC_LOG_LINES:
+        lines = lines[-SERVER_DIAGNOSTIC_LOG_LINES:]
+    text = "\n".join(lines)
+    if len(text) > SERVER_DIAGNOSTIC_LOG_CHARS:
+        text = text[-SERVER_DIAGNOSTIC_LOG_CHARS:]
+    return text
+
+
+def _probe_server(url: str) -> tuple[bool, str]:
+    """Probe one local server URL and return readiness plus a concise reason."""
+    try:
+        with urlopen(url, timeout=0.25) as response:
+            status = getattr(response, "status", None)
+            if isinstance(status, int) and 200 <= status < 500:
+                return True, f"HTTP {status}"
+            return False, f"HTTP {status if status is not None else 'unknown'}"
+    except HTTPError as error:
+        # urllib raises HTTPError for 4xx responses even though they prove that
+        # the HTTP server is reachable and ready to serve requests.
+        if 400 <= error.code < 500:
+            return True, f"HTTP {error.code}"
+        return False, f"HTTP {error.code}: {error.reason}"
+    except (OSError, URLError) as error:
+        reason = getattr(error, "reason", None)
+        detail = str(reason or error).strip() or error.__class__.__name__
+        return False, f"{error.__class__.__name__}: {detail}"
+
+
 def _wait_for_server(url: str, *, timeout: float) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            with urlopen(url, timeout=0.25) as response:
-                if 200 <= response.status < 500:
-                    return True
-        except (OSError, URLError):
-            time.sleep(0.1)
+        ready, _detail = _probe_server(url)
+        if ready:
+            return True
+        time.sleep(0.1)
     return False
 
 

--- a/maw/launcher_batch.py
+++ b/maw/launcher_batch.py
@@ -27,6 +27,7 @@ class BatchItem:
     item_id: str
     request: TranscriptionRequest | None
     preflight_error: str = ""
+    preflight_code: str = ""
 
 
 BatchEvent = Callable[[Mapping[str, object]], None]
@@ -80,6 +81,7 @@ def run_batch(
                 "id": item.item_id,
                 "status": "failed",
                 "index": index,
+                "code": item.preflight_code or "batch_item_invalid",
                 "error": item.preflight_error or "Batch item is invalid.",
             }
             outcomes.append(outcome)
@@ -146,7 +148,13 @@ def run_batch(
             TranscriptionProcessError,
             ValueError,
         ) as error:
-            outcome = {"id": item.item_id, "status": "failed", "index": index, "error": str(error)}
+            outcome = {
+                "id": item.item_id,
+                "status": "failed",
+                "index": index,
+                "code": "postprocess_failed" if isinstance(error, PostprocessPipelineError) else "transcription_failed",
+                "error": str(error),
+            }
         outcomes.append(outcome)
         _update_manifest(manifest, index, outcome, manifest_path)
         _emit(on_event, {"type": "batch_item", **outcome})

--- a/maw/local_log.py
+++ b/maw/local_log.py
@@ -23,9 +23,16 @@ from maw.app_paths import default_log_directory
 LOG_RETENTION_DAYS = 7
 _LOG_FILE_PATTERN = "maw-*.log"
 
-# 防御性打码：批处理链路已有 _without_secrets 先例，这里针对 sk-xxx
-# 形态再做一层兜底，避免事件消息意外携带 API Key。
+# 防御性打码：批处理链路已有 _without_secrets 先例，这里再覆盖
+# 自由文本中的常见密钥赋值和 Authorization 形式，避免事件消息或异常
+# traceback 意外把凭据写入日志。
 _SECRET_PATTERN = re.compile(r"sk-[A-Za-z0-9_-]{4,}")
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r'''(?i)(\b[\w.-]*(?:api[-_ ]?key|access[-_ ]?token|secret(?:[-_ ]?(?:key|id))?|password)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)'''
+)
+_BEARER_PATTERN = re.compile(
+    r'''(?i)(\bauthorization\s*[:=]\s*bearer\s+|\bbearer\s*(?::|=|\s)\s*)("[^"]*"|'[^']*'|[^\s,;]+)'''
+)
 _SENSITIVE_KEYS = ("key", "secret", "token", "password")
 
 
@@ -36,6 +43,14 @@ def _log_path_for(directory: Path, day: datetime) -> Path:
 def _sensitive_key(key: str) -> bool:
     lowered = key.casefold()
     return any(token in lowered for token in _SENSITIVE_KEYS)
+
+
+def redact_sensitive_text(value: object) -> str:
+    """Mask credentials embedded in free-form diagnostic text."""
+    text = str(value)
+    text = _SECRET_ASSIGNMENT_PATTERN.sub(r"\1[REDACTED]", text)
+    text = _BEARER_PATTERN.sub(r"\1[REDACTED]", text)
+    return _SECRET_PATTERN.sub("sk-***", text)
 
 
 def _scalar_pairs(value: object) -> list[tuple[str, object]]:
@@ -73,7 +88,7 @@ def _format_event(event: Mapping[str, object]) -> str:
                 parts.append(f"{str(key)}={value}")
         payload = " ".join(parts)
         body = f"[{event_type}] {payload}" if payload else f"[{event_type}]"
-    return _SECRET_PATTERN.sub("sk-***", body)
+    return redact_sensitive_text(body)
 
 
 def format_log_line(event: Mapping[str, object], *, now: datetime) -> str:
@@ -116,7 +131,7 @@ class LocalLogSink:
         """把一段非事件文本（如 print 输出）写成一行的日志。"""
         try:
             stamp = self._now().strftime("%H:%M:%S.%f")[:-3]
-            line = f"{stamp} [{label}] " + _SECRET_PATTERN.sub("sk-***", str(text))
+            line = f"{stamp} [{label}] " + redact_sensitive_text(text)
         except Exception:
             return
         self._write_line(line)

--- a/maw_gui.py
+++ b/maw_gui.py
@@ -250,7 +250,9 @@ def _startup_error_fallback_log_path() -> Path:
 
 
 def _write_startup_error_log(error: Exception) -> Path | None:
-    content = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    from maw.local_log import redact_sensitive_text
+
+    content = redact_sensitive_text("".join(traceback.format_exception(type(error), error, error.__traceback__)))
     paths = [_startup_error_log_path()]
     fallback = _startup_error_fallback_log_path()
     if fallback not in paths:

--- a/tests/e2e/launcher-interactions.spec.mjs
+++ b/tests/e2e/launcher-interactions.spec.mjs
@@ -395,6 +395,40 @@ test('error reports copy safe details and support file URL fallback', async ({ p
   await expect(page.locator('#errorNoticeCopy')).toHaveText('复制错误报告');
 });
 
+test('server timeout diagnostics are visible and copied with the error report', async ({ page }) => {
+  await page.goto(`file://${launcherPath}`);
+  await page.waitForFunction(() => window.MAWLauncher?.config?.postprocessProviders?.length > 0);
+  await page.evaluate(() => {
+    window.__copiedReports = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async (text) => window.__copiedReports.push(text) },
+    });
+    window.MAWLauncher.onBackendEvent({
+      type: 'error',
+      code: 'server_no_response',
+      detail: 'http://127.0.0.1:8250/',
+      diagnostics: {
+        processState: 'running',
+        pid: 4321,
+        lastProbe: 'Connection refused',
+        startupLogTail: 'MAWE started\n[http] probe pending',
+      },
+    });
+  });
+  await expect(page.locator('#errorNoticeDiagnostics')).toBeVisible();
+  await expect(page.locator('#errorNoticeDiagnostics')).toContainText('进程状态: 仍在运行');
+  await expect(page.locator('#errorNoticeDiagnostics')).toContainText('PID: 4321');
+  await expect(page.locator('#errorNoticeDiagnostics')).toContainText('最后探测: Connection refused');
+  await expect(page.locator('#errorNoticeDiagnostics')).toContainText('启动日志尾部: MAWE started');
+  await page.locator('#errorNoticeCopy').click();
+  await expect(page.locator('#errorNoticeCopy')).toHaveText('已复制');
+  const report = await page.evaluate(() => window.__copiedReports[0]);
+  expect(report).toContain('诊断信息:');
+  expect(report).toContain('PID: 4321');
+  expect(report).toContain('Connection refused');
+});
+
 test('unknown errors stay generic and do not expose FFmpeg actions', async ({ page }) => {
   await page.goto(`file://${launcherPath}`);
   await page.waitForFunction(() => window.MAWLauncher?.config?.postprocessProviders?.length > 0);

--- a/tests/test_gui_web.py
+++ b/tests/test_gui_web.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import final
 from unittest import mock
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -1654,6 +1654,54 @@ class GuiWebBridgeTests(unittest.TestCase):
         self.assertEqual(result["code"], "server_no_response")
         open_browser.assert_not_called()
 
+    def test_start_server_includes_bounded_diagnostics_when_process_stays_alive(self) -> None:
+        project = self.root / "project.json"
+        media = self.root / "clip.mp4"
+        project.write_text(json.dumps({"media": str(media), "segments": []}), encoding="utf-8")
+        media.write_bytes(b"media")
+
+        class RunningProcess:
+            pid = 4321
+            returncode = None
+
+            def poll(self) -> int | None:
+                return None
+
+            def terminate(self) -> None:
+                self.returncode = -15
+
+            def wait(self, timeout: float | None = None) -> int:
+                return self.returncode or 0
+
+        def spawn(*_args, **kwargs):
+            kwargs["stdout"].write((
+                "MAWE 已启动\n"
+                "[project] 等待工程加载\n"
+                "Authorization: Bearer secret-token\n"
+            ).encode("utf-8"))
+            kwargs["stdout"].flush()
+            return RunningProcess()
+
+        with mock.patch("maw.gui_web.subprocess.Popen", side_effect=spawn):
+            with mock.patch("maw.gui_web._wait_for_server", return_value=False):
+                with mock.patch("maw.gui_web._probe_server", return_value=(False, "Connection refused")):
+                    with mock.patch("maw.gui_web.terminate_process_tree"):
+                        with mock.patch("maw.gui_web.release_process_tree"):
+                            result = self.api.start_server({"jsonPath": str(project), "mediaPath": str(media), "port": "9876"})
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], "server_no_response")
+        self.assertEqual(result["detail"], "http://127.0.0.1:9876/")
+        self.assertEqual(
+            result["diagnostics"],
+            {
+                "processState": "running",
+                "pid": 4321,
+                "lastProbe": "Connection refused",
+                "startupLogTail": "MAWE 已启动\n[project] 等待工程加载\nAuthorization: Bearer [REDACTED]",
+            },
+        )
+
     def test_start_server_exposes_child_startup_log_when_process_exits(self) -> None:
         project = self.root / "project.json"
         media = self.root / "clip.mp4"
@@ -1716,6 +1764,16 @@ class GuiWebBridgeTests(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         self.assertEqual(calls, ["wait", "wait"])
+
+    def test_server_probe_treats_http_client_errors_as_reachable(self) -> None:
+        from maw.gui_web import _probe_server
+
+        error = HTTPError("http://127.0.0.1:9876/", 404, "Not found", {}, None)
+        with mock.patch("maw.gui_web.urlopen", side_effect=error):
+            ready, detail = _probe_server("http://127.0.0.1:9876/")
+
+        self.assertTrue(ready)
+        self.assertEqual(detail, "HTTP 404")
 
     def test_start_server_returns_existing_server_url_without_spawning(self) -> None:
         """Given a responding port, When starting server, Then it reports the existing server instead of spawning."""

--- a/tests/test_gui_workflow.py
+++ b/tests/test_gui_workflow.py
@@ -31,7 +31,7 @@ from maw.gui_workflow import (  # noqa: E402
     run_transcription,
 )
 from maw.gui_platform import _terminate_registered_job, terminate_process_tree  # noqa: E402
-from maw_gui import _is_ffmpeg_missing_error, _startup_error_log_path  # noqa: E402
+from maw_gui import _is_ffmpeg_missing_error, _startup_error_log_path, _write_startup_error_log  # noqa: E402
 
 
 def _write_bwf_wav(path: Path, sample_rate: int, time_reference_samples: int) -> None:
@@ -991,6 +991,21 @@ class GuiWorkflowTests(unittest.TestCase):
                 maw_gui._startup_error_fallback_log_path(),
                 self.root / "LocalAppData" / "MAW" / "logs" / "launcher-startup.log",
             )
+
+    def test_startup_error_log_redacts_secret_assignments(self) -> None:
+        import maw_gui
+
+        target = self.root / "launcher-startup.log"
+        error = RuntimeError("DASHSCOPE_API_KEY=dash-secret Authorization: Bearer bearer-secret")
+        with mock.patch.object(maw_gui, "_startup_error_log_path", return_value=target), mock.patch.object(
+            maw_gui, "_startup_error_fallback_log_path", return_value=target
+        ):
+            self.assertEqual(_write_startup_error_log(error), target)
+
+        content = target.read_text(encoding="utf-8")
+        self.assertNotIn("dash-secret", content)
+        self.assertNotIn("bearer-secret", content)
+        self.assertIn("[REDACTED]", content)
 
     def test_entrypoint_debug_aliases_configure_launcher_debug_modes(self) -> None:
         import maw_gui

--- a/tests/test_launcher_batch.py
+++ b/tests/test_launcher_batch.py
@@ -68,6 +68,7 @@ class BatchRunnerTests(unittest.TestCase):
 
         self.assertEqual(started, ["clip-0", "clip-1", "clip-2"])
         self.assertEqual([item["status"] for item in result["outcomes"]], ["done", "failed", "done"])
+        self.assertEqual(result["outcomes"][1]["code"], "transcription_failed")
         self.assertEqual(result["outcomes"][1]["error"], "provider failed")
 
     def test_cancel_marks_remaining_items_without_running_them(self) -> None:
@@ -192,7 +193,7 @@ class BatchRunnerTests(unittest.TestCase):
     def test_preflight_failure_isolated_to_one_item(self) -> None:
         valid = self._items(2)
         raw = (
-            BatchItem("bad", None, "Media file does not exist."),
+            BatchItem("bad", None, "Media file does not exist.", "media_not_found"),
             valid[1],
         )
         started: list[str] = []
@@ -205,6 +206,7 @@ class BatchRunnerTests(unittest.TestCase):
 
         self.assertEqual(started, ["clip-1"])
         self.assertEqual([item["status"] for item in result["outcomes"]], ["failed", "done"])
+        self.assertEqual(result["outcomes"][0]["code"], "media_not_found")
 
     def test_request_none_without_preflight_error_is_isolated(self) -> None:
         valid = self._items(1)[0]
@@ -218,6 +220,7 @@ class BatchRunnerTests(unittest.TestCase):
 
         self.assertEqual(started, ["clip-0"])
         self.assertEqual([item["status"] for item in result["outcomes"]], ["failed", "done"])
+        self.assertEqual(result["outcomes"][0]["code"], "batch_item_invalid")
         self.assertTrue(result["outcomes"][0]["error"])
 
     def test_batch_passes_ocr_runtime_root_and_routes_pipeline_logs(self) -> None:

--- a/tests/test_local_log.py
+++ b/tests/test_local_log.py
@@ -15,6 +15,7 @@ from maw.local_log import (
     LocalLogSink,
     TeeWriter,
     _log_path_for,
+    redact_sensitive_text,
     default_log_directory,
     format_log_line,
     install_stdio_tee,
@@ -57,6 +58,15 @@ class LogLineFormattingTests(unittest.TestCase):
         line = format_log_line({"type": "log", "message": "auth=sk-abc12345defxyz"}, now=_now())
         self.assertIn("sk-***", line)
         self.assertNotIn("sk-abc12345defxyz", line)
+
+    def test_common_secret_assignments_are_masked(self) -> None:
+        text = redact_sensitive_text(
+            "DASHSCOPE_API_KEY=dash-secret TENCENT_SECRET_ID='tencent-id' Authorization: Bearer bearer-secret"
+        )
+        self.assertNotIn("dash-secret", text)
+        self.assertNotIn("tencent-id", text)
+        self.assertNotIn("bearer-secret", text)
+        self.assertEqual(text.count("[REDACTED]"), 3)
 
     def test_sensitive_keys_are_dropped_from_structured_payload(self) -> None:
         line = format_log_line({"type": "batch_item", "id": "1", "apiKey": "sk-x"}, now=_now())

--- a/web/launcher/batch.js
+++ b/web/launcher/batch.js
@@ -39,10 +39,27 @@
     return { ...event, type };
   }
 
-  function setItemStatus(item, status, detail = "") {
+  function itemErrorText(code, detail) {
+    const raw = String(detail || "");
+    const translate = window.MAWLauncher?.errorText;
+    if (!code || typeof translate !== "function") return raw;
+    return translate(code, raw) || raw;
+  }
+
+  function setItemDetail(item, detail = "", code = "") {
+    const raw = String(detail || "");
+    const effectiveCode = String(code || item.errorCode || "");
+    if (effectiveCode) item.errorCode = effectiveCode;
+    if (!effectiveCode && !raw) return;
+    const friendly = itemErrorText(effectiveCode, raw) || raw;
+    item.detail = friendly;
+    item.rawDetail = friendly !== raw && !friendly.includes(raw) ? raw : "";
+  }
+
+  function setItemStatus(item, status, detail = "", code = "") {
     const previousStatus = item.status;
     item.status = status || item.status;
-    if (detail) item.detail = detail;
+    setItemDetail(item, detail, code);
     if ((previousStatus === "running" || previousStatus === "queued") && ["done", "failed", "cancelled", "skipped"].includes(item.status)) {
       state.progress.finished += 1;
       if (item.status === "done") state.progress.done += 1;
@@ -122,7 +139,7 @@
         const summary = document.createElement("summary");
         summary.textContent = item.status === "failed" ? t("batch_error_details") : t("batch_log_details");
         const log = document.createElement("pre");
-        log.textContent = [item.detail, ...item.logs].filter(Boolean).join("\n");
+        log.textContent = [item.detail, item.rawDetail ? `[detail] ${item.rawDetail}` : "", ...item.logs].filter(Boolean).join("\n");
         details.append(summary, log);
         details.open = expandedDetails.has(item.id);
         body.append(details);
@@ -166,7 +183,7 @@
         return;
       }
       existing.add(key);
-      state.items.push({ id: `batch-${state.nextId}`, index: state.items.length, mediaPath, status: "queued", detail: "", logs: [], result: null });
+      state.items.push({ id: `batch-${state.nextId}`, index: state.items.length, mediaPath, status: "queued", detail: "", rawDetail: "", errorCode: "", logs: [], result: null });
       state.nextId += 1;
     });
     renderQueue();
@@ -235,7 +252,7 @@
       $("status").textContent = t("batch_complete");
       return;
     }
-    itemsToRun.forEach((item) => { item.status = "queued"; item.detail = ""; item.logs = []; item.result = null; });
+    itemsToRun.forEach((item) => { item.status = "queued"; item.detail = ""; item.rawDetail = ""; item.errorCode = ""; item.logs = []; item.result = null; });
     state.progress = { total: itemsToRun.length, finished: 0, done: 0, failed: 0 };
     state.running = true;
     state.cancelling = false;
@@ -306,12 +323,13 @@
       const nested = event.item && typeof event.item === "object" ? event.item : {};
       item.result = event.result || nested.result || ((event.srtPath || event.jsonPath || event.htmlPath) ? { srtPath: event.srtPath || "", jsonPath: event.jsonPath || "", htmlPath: event.htmlPath || "" } : item.result);
       const detail = event.error || event.detail || nested.error || nested.detail || "";
+      const code = event.code || nested.code || "";
       const nextStatus = event.status || nested.status || (item.result ? "done" : item.status);
       if (nextStatus === "running") {
         $("status").textContent = t("batch_progress").replace("{current}", String(item.index + 1)).replace("{total}", String(state.progress.total)).replace("{name}", fileName(item.mediaPath));
         window.MAWLauncher.appendLog?.($("status").textContent);
       }
-      setItemStatus(item, nextStatus, detail);
+      setItemStatus(item, nextStatus, detail, code);
       return;
     }
     if (event.type === "batchDone") {
@@ -328,13 +346,13 @@
         const htmlPath = outcome.htmlPath || outcome.html_path || result.htmlPath || result.html_path || "";
         if (srtPath || jsonPath || htmlPath) item.result = { srtPath, jsonPath, htmlPath };
         item.status = outcome.status || item.status;
-        item.detail = outcome.error || outcome.detail || item.detail;
+        setItemDetail(item, outcome.error || outcome.detail || "", outcome.code || "");
       });
       // batchDone 是终态真源：未被 outcomes 覆盖、仍停在 queued/running 的行必须落到终态。
       state.items.forEach((item) => {
         if (item.status !== "queued" && item.status !== "running") return;
         item.status = cancelled ? "cancelled" : "failed";
-        if (!cancelled && !item.detail) item.detail = t("batch_outcome_missing");
+        if (!cancelled && !item.detail) setItemDetail(item, t("batch_outcome_missing"));
       });
       state.running = false;
       state.cancelling = false;

--- a/web/launcher/index.html
+++ b/web/launcher/index.html
@@ -442,6 +442,7 @@
       <div class="error-notice-copy">
         <strong id="errorNoticeTitle" data-i18n="error_notice_title">任务未完成</strong>
         <p id="errorNoticeMessage"></p>
+        <p id="errorNoticeDiagnostics" class="error-notice-detail hidden"></p>
       </div>
       <div id="errorNoticeActions" class="error-notice-actions">
         <button id="errorNoticeAction" class="ghost small hidden" type="button"></button>

--- a/web/launcher/launcher.css
+++ b/web/launcher/launcher.css
@@ -1450,6 +1450,25 @@ textarea::placeholder {
   overflow-wrap: anywhere;
 }
 
+.error-notice-detail {
+  max-height: 160px;
+  margin-top: 8px !important;
+  padding: 8px 10px;
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted) !important;
+  background: var(--bg-input);
+  font-family: var(--font-mono);
+  font-size: 12px !important;
+  line-height: 1.45 !important;
+  overflow-wrap: anywhere;
+}
+
+.error-notice-detail .status-link {
+  color: var(--accent);
+}
+
 .error-notice-actions {
   display: flex;
   align-items: center;

--- a/web/launcher/launcher.js
+++ b/web/launcher/launcher.js
@@ -802,7 +802,20 @@
       server_start_failed: (detail) => `编辑器服务器启动失败：${detail || "请查看下方日志。"}`,
       alignment_server_no_response: (detail) => `口播对齐 Server 没有响应：${detail || "请重试。"}`,
       alignment_server_start_failed: (detail) => `口播对齐 Server 启动失败：${detail || "请查看日志后重试。"}`,
-      sticker_dir_invalid: "表情包根目录不存在。"
+      sticker_dir_invalid: "表情包根目录不存在。",
+      postprocess_connection_failed: (detail) => `大模型连接测试失败：${detail || "请检查 API Key、API 地址和网络连接。"}`,
+      postprocess_models_failed: (detail) => `获取模型列表失败：${detail || "请检查 API Key 和 API 地址是否正确。"}`,
+      batch_items_invalid: "批量任务中存在无效项目，请检查媒体文件路径。",
+      batch_item_invalid: "该批量项目无效，请检查媒体文件路径。",
+      batch_items_required: "请添加至少一个批量任务项目。",
+      mose_not_found: "未找到 MOSE 桌面编辑器，请确认 MAW 完整安装。",
+      mose_start_failed: "MOSE 桌面编辑器启动失败，请查看日志后重试。",
+      script_preview_failed: (detail) => `脚本预览失败：${detail || "请检查脚本文件格式。"}`,
+      script_preview_missing: "请先选择脚本文件。",
+      alignment_media_invalid: "口播对齐的媒体文件不存在或格式不支持。",
+      alignment_project_invalid: "口播对齐需要有效的 .mosp 或 .json 工程文件。",
+      alignment_script_missing: "口播对齐需要有效的脚本文件。",
+      invalid_reasoning_mode: (detail) => `推理模式设置无效：${detail || "请检查后处理配置。"}`,
     },
     en: {
       json_not_found: "Project file does not exist. Check the path.",
@@ -853,7 +866,20 @@
       server_start_failed: (detail) => `The editor server failed to start: ${detail || "check the logs below."}`,
       alignment_server_no_response: (detail) => `The speech-alignment server did not respond: ${detail || "retry the operation."}`,
       alignment_server_start_failed: (detail) => `The speech-alignment server failed to start: ${detail || "check the log and retry."}`,
-      sticker_dir_invalid: "Sticker root directory does not exist."
+      sticker_dir_invalid: "Sticker root directory does not exist.",
+      postprocess_connection_failed: (detail) => `LLM connection test failed: ${detail || "check the API key, URL, and network."}`,
+      postprocess_models_failed: (detail) => `Failed to get model list: ${detail || "check the API key and URL."}`,
+      batch_items_invalid: "Some batch items are invalid. Check the media file paths.",
+      batch_item_invalid: "This batch item is invalid. Check the media file path.",
+      batch_items_required: "Add at least one batch item.",
+      mose_not_found: "MOSE desktop editor was not found. Ensure MAW is fully installed.",
+      mose_start_failed: "MOSE desktop editor failed to start. Check the log and retry.",
+      script_preview_failed: (detail) => `Script preview failed: ${detail || "check the script file format."}`,
+      script_preview_missing: "Choose a script file first.",
+      alignment_media_invalid: "The speech-alignment media file does not exist or is unsupported.",
+      alignment_project_invalid: "Speech alignment requires a valid .mosp or .json project.",
+      alignment_script_missing: "Speech alignment requires a valid script file.",
+      invalid_reasoning_mode: (detail) => `Invalid reasoning mode: ${detail || "check the post-processing settings."}`,
     }
   };
   Object.assign(STRINGS.zh, {
@@ -1123,6 +1149,24 @@
   }
 
   const t = (key) => STRINGS[state.lang][key] || key;
+  const DIAGNOSTIC_LABELS = {
+    zh: { processState: "进程状态", pid: "PID", lastProbe: "最后探测", startupLogTail: "启动日志尾部" },
+    en: { processState: "Process", pid: "PID", lastProbe: "Last probe", startupLogTail: "Startup log tail" },
+  };
+  function diagnosticText(value) {
+    if (value === null || value === undefined || value === "") return "";
+    if (typeof value === "string") return redactSensitive(value).trim();
+    if (typeof value !== "object") return redactSensitive(String(value));
+    return Object.entries(value).map(([key, item]) => {
+      if (item === null || item === undefined || item === "") return "";
+      const raw = typeof item === "object" ? JSON.stringify(item) : String(item);
+      const shown = key === "processState" && item === "running"
+        ? (state.lang === "zh" ? "仍在运行" : "running")
+        : raw;
+      const label = DIAGNOSTIC_LABELS[state.lang]?.[key] || key;
+      return label + ": " + redactSensitive(shown);
+    }).filter(Boolean).join("\n");
+  }
   function compactDetail(detail) { return String(detail || "").replace(/\s+/g, " ").trim(); }
   function errText(code, detail) { const entry = ERROR_TEXT[state.lang][code]; const compact = compactDetail(detail); if (typeof entry === "function") return entry(compact); return entry || compact || t("failed"); }
   const ext = (path) => (path.match(/\.[^.\\/]+$/)?.[0] || "").toLowerCase();
@@ -1196,14 +1240,16 @@
     // output before an error report is copied out of the local Launcher.
     return String(value || "")
       .replace(/\bsk-[A-Za-z0-9_-]{4,}\b/gu, "[REDACTED_API_KEY]")
-      .replace(/(\b(?:api[-_ ]?key|access[-_ ]?token)\s*[:=]\s*)([^\s,;]+)/giu, "$1[REDACTED]")
-      .replace(/(\bbearer\s*(?::|=|\s)\s*)([^\s,;]+)/giu, "$1[REDACTED]");
+      .replace(/(\b[\w.-]*(?:api[-_ ]?key|access[-_ ]?token|secret(?:[-_ ]?(?:key|id))?|password)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/giu, "$1[REDACTED]")
+      .replace(/(\bauthorization\s*[:=]\s*bearer\s+|\bbearer\s*(?::|=|\s)\s*)("[^"]*"|'[^']*'|[^\s,;]+)/giu, "$1[REDACTED]");
   }
   function clearErrorReport() {
     state.errorReport = null;
     if (state.errorCopyTimer) { clearTimeout(state.errorCopyTimer); state.errorCopyTimer = 0; }
     const button = $("errorNoticeCopy");
     if (button) { button.disabled = false; button.textContent = t("error_copy_report"); }
+    const diagnostics = $("errorNoticeDiagnostics");
+    if (diagnostics) { diagnostics.replaceChildren(); diagnostics.classList.add("hidden"); }
   }
   function hideErrorNotice() {
     const notice = $("errorNotice");
@@ -1211,14 +1257,20 @@
     notice.dataset.action = "";
     clearErrorReport();
   }
-  function showErrorNotice(message, code = "", detail = "") {
+  function showErrorNotice(message, code = "", detail = "", diagnostics = "") {
     const notice = $("errorNotice");
     const action = $("errorNoticeAction");
     const issue = $("errorNoticeIssue");
     clearErrorReport();
-    state.errorReport = { code: code || "backend_error", message: String(message || ""), detail: String(detail || "") };
+    const diagnostic = diagnosticText(diagnostics);
+    state.errorReport = { code: code || "backend_error", message: String(message || ""), detail: String(detail || ""), diagnostics: diagnostic };
     $("errorNoticeTitle").textContent = t("error_notice_title");
     renderMessage($("errorNoticeMessage"), message);
+    const diagnosticNode = $("errorNoticeDiagnostics");
+    if (diagnosticNode) {
+      renderMessage(diagnosticNode, diagnostic);
+      diagnosticNode.classList.toggle("hidden", !diagnostic);
+    }
     if (code === "ffmpeg_missing") {
       notice.dataset.action = "ffmpeg-settings";
       action.textContent = t("error_open_ffmpeg_settings");
@@ -1241,12 +1293,14 @@
     const version = state.config?.appVersion || $("appVersion")?.textContent?.trim() || "unknown";
     const log = redactSensitive($("log")?.textContent || "");
     const labels = state.lang === "zh"
-      ? { title: "MAW Launcher 错误报告", version: "版本", code: "错误码", message: "提示", detail: "详细信息", log: "日志" }
-      : { title: "MAW Launcher error report", version: "Version", code: "Error code", message: "Message", detail: "Detail", log: "Log" };
+      ? { title: "MAW Launcher 错误报告", version: "版本", code: "错误码", message: "提示", detail: "详细信息", diagnostics: "诊断信息", log: "日志" }
+      : { title: "MAW Launcher error report", version: "Version", code: "Error code", message: "Message", detail: "Detail", diagnostics: "Diagnostics", log: "Log" };
     const message = compactDetail(report.message);
     const detail = compactDetail(report.detail);
+    const diagnostics = compactDetail(report.diagnostics);
     return [
       labels.title,
+      ...(diagnostics ? [labels.diagnostics + ": " + redactSensitive(report.diagnostics)] : []),
       `${labels.version}: ${redactSensitive(version)}`,
       `${labels.code}: ${redactSensitive(report.code)}`,
       `${labels.message}: ${redactSensitive(report.message)}`,
@@ -1648,7 +1702,20 @@
     return setDroppedPath("serverMediaPath", value);
   }
   function setJsonPath(path) { $("jsonPath").value = path; setError("jsonPath", ""); if (path !== state.serverProjectPath) $("openMawe").classList.add("attention"); refreshServerMedia(); window.MAWLauncher?.onProjectPathChanged?.(); }
-  function applyErrorResult(result, logDetail = true) { const detail = result.detail || result.error || ""; const message = errText(result.code, detail); const fieldMessage = result.code === "server_start_failed" ? t("server_start_failed_hint") : (result.code === "server_no_response" ? t("server_no_response_hint") : message); if (result.field) setError(result.field, fieldMessage); if (result.field === "port" || result.field === "serverMediaPath" || result.field === "jsonPath") expandServer(); if (result.postprocessStep) window.MAWLauncher?.openAutoPostprocessStep?.(result.postprocessStep, result.field); else if (result.field === "autoPostprocessEnabled") $("autoPostprocessCard")?.scrollIntoView({ behavior: "smooth", block: "start" }); setStatus(message); if (logDetail && detail) appendLog(`[detail] ${detail}`); showErrorNotice(message, result.code || "", detail); }
+  function applyErrorResult(result, logDetail = true) {
+    const detail = result.detail || result.error || "";
+    const diagnostics = diagnosticText(result.diagnostics);
+    const message = errText(result.code, detail);
+    const fieldMessage = result.code === "server_start_failed" ? t("server_start_failed_hint") : (result.code === "server_no_response" ? t("server_no_response_hint") : message);
+    if (result.field) setError(result.field, fieldMessage);
+    if (result.field === "port" || result.field === "serverMediaPath" || result.field === "jsonPath") expandServer();
+    if (result.postprocessStep) window.MAWLauncher?.openAutoPostprocessStep?.(result.postprocessStep, result.field);
+    else if (result.field === "autoPostprocessEnabled") $("autoPostprocessCard")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    setStatus(message);
+    if (logDetail && detail) appendLog(`[detail] ${detail}`);
+    if (logDetail && diagnostics) appendLog("[diagnostics] " + diagnostics);
+    showErrorNotice(message, result.code || "", detail, diagnostics);
+  }
   function validateSegmentation(data) { for (const [field, minimum] of [["maxLen", 1], ["minLen", 1], ["gapSplit", 0]]) { const value = data[field]; if (!value) continue; if (!/^\d+$/u.test(value) || !Number.isSafeInteger(Number(value)) || Number(value) < minimum) return fail(field, errText("segmentation_invalid", "")); } if (data.maxLen && data.minLen && Number(data.maxLen) < Number(data.minLen)) return fail("maxLen", errText("segmentation_invalid", "")); return true; }
   function validateLocal() { clearErrors(); const data = formPayload(); if (!data.mediaPath) return fail("mediaPath", errText("media_not_found", "")); if (!data.srtPath) return fail("srtPath", errText("output_missing", "")); if (!validateSegmentation(data)) return false; if (isLocalProvider()) { const runtime = state.config.localRuntime || {}; const status = localStatus(); if (!runtime.ready && runtime.status !== "ready") return fail("model", errText("local_runtime_missing", "")); if (status.status === "runtime_missing") return fail("model", errText("local_runtime_missing", "")); if (status.status === "path_invalid") return fail("localModelPath", errText("local_model_path_invalid", "")); if (status.status === "path_mismatch") return fail("localModelPath", errText("local_model_path_mismatch", "")); if (status.status === "missing") return fail("model", errText("local_model_missing", "")); if (status.status === "partial") return fail("model", errText("local_model_incomplete", "")); return true; } if (provider().requiresApiKey !== false && !data.apiKey && !provider().apiKey) return fail("apiKey", errText("api_key_missing", "")); if (provider().regions.length > 0 && data.region === "singapore" && !data.workspaceId) return fail("workspaceId", errText("workspace_missing", "")); if (provider().id === "qwen" && selectedModel().supportsContext && Array.from(data.qwenAudioContext).length > 400) return fail("qwenAudioContext", errText("context_too_long", "")); if (provider().id === "soniox" && selectedModel().supportsContext && Array.from([data.sonioxContextGeneral, data.sonioxContextText, data.sonioxContextTerms, data.sonioxContextTranslationTerms].join("\n")).length > 10000) return fail("sonioxContextText", errText("soniox_context_too_long", "")); if (provider().id === "qwen" && selectedModel().supportsHotwords && data.qwenAudioHotwordsMode === "file" && ext(data.qwenAudioHotwordsFile) !== ".txt") return fail("qwenAudioHotwordsFile", errText("hotwords_file_missing", "")); return true; }
   function fail(field, message) { setError(field, message); setStatus(message); const input = $(field); if (input && input.scrollIntoView) input.scrollIntoView({ behavior: "smooth", block: "center" }); return false; }
@@ -1991,11 +2058,13 @@
       setRunning(false);
       $("retryPostprocess")?.classList.toggle("hidden", !event.canRetry);
       const detail = event.detail || event.message || "";
+      const diagnostics = diagnosticText(event.diagnostics);
       const message = event.code ? errText(event.code, detail) : detail || t("failed");
-      // 友好提示归错误卡片、status 与复制报告的结构化字段所有；日志只保留后端原始 detail。
+      // 友好提示归错误卡片与 status；复制报告同时保留 detail 和诊断信息。
       setStatus(message);
       if (detail) appendLog(`[detail] ${detail}`);
-      showErrorNotice(message, event.code || "", detail);
+      if (diagnostics) appendLog("[diagnostics] " + diagnostics);
+      showErrorNotice(message, event.code || "", detail, diagnostics);
       renderLocalModelStatus();
     }
     if (event.type === "done") {


### PR DESCRIPTION
## 摘要

本 PR 为 Launcher 补充一部分常见错误的友好提示，并增强编辑器 Server 启动无响应时的诊断信息。

## 更新内容

### 1. 补充错误提示

为后处理、批量任务、MOSE、脚本预览、口播对齐和推理模式等场景增加中英文错误提示，包括：

- 大模型连接和模型列表获取失败
- 批量项目无效或缺少批量任务
- MOSE 编辑器不存在或启动失败
- 脚本预览失败或未选择脚本
- 口播对齐工程、文稿和媒体文件错误
- 推理模式配置无效

批处理结果会保留稳定错误码，使每个失败项目都能显示对应说明。

### 2. 增强 Server 无响应诊断

`server_no_response` 现在会附带：

- 子进程状态
- PID
- 最后一次 HTTP 探测结果
- 有界的启动日志尾部

HTTP 4xx 响应会被视为服务已经可达。本 PR 不改变现有端口分配和启动逻辑。

### 3. 保护错误报告中的敏感信息

本地日志、启动日志和复制出的错误报告会对常见的 API Key、Token、Secret、Password 和 Bearer Token 进行脱敏，同时保留必要的原始错误细节用于排查。

### 4. 保持未知错误可诊断

未识别错误仍会保留详细信息、日志和 Issue 入口，不会被静默吞掉。

## 范围

本 PR 只关注 Launcher 错误提示和诊断信息，不涉及 FFmpeg 解析、发布流程、对齐功能实现或其他无关提交。

## 验证

- Python 测试：986 个通过，跳过 6 个
- `node --check web/launcher/launcher.js` 通过
- `git diff --check` 通过