### PR TITLE
fix(release): Linux 打包改用 BtbN latest 稳定分支资产，摆脱会过期的 dated pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本项目采用 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/) 的记录方式。
 
+## [Unreleased]
+
+### 🐛 修复
+
+- **Linux 打包不再依赖会被 BtbN 删除的固定 autobuild** ： AppImage 打包此前写死某个 dated autobuild 的下载地址与 SHA256，而 BtbN 只保留最近十来天的 dated release，过期即 404；下载又未开 `--fail`，404 页面会被存成文件并报成「校验和不匹配」，1.6.0-beta.3 的 Linux 打包即因此失败。现改为固定使用 `latest` release 中 FFmpeg 8.1 稳定分支资产的永久直链（与 Windows 的 8.1.2 / macOS 的 8.1 同大版本），开启 curl `--fail`，随包下载上游 `checksums.sha256` 比对完整性，解压后再校验二进制自报版本；实际打进包的归档哈希仍记录在 `ffmpeg/SOURCE.txt`。升级大版本只需改脚本里的 `FFMPEG_BRANCH`。
+
 ## [1.6.0-beta.3] - 2026-09-10
 
 ### 🚀 全新特性

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -23,34 +23,56 @@ uv run --group build pyinstaller --noconfirm --clean MAW.spec
 # user-facing FAQ at the AppImage root as well, where users can find it easily.
 cp "FAQ-常见问题.txt" "dist/MAW/FAQ-常见问题.txt"
 
-echo "==> 2/6 准备静态 ffmpeg（BtbN FFmpeg-Builds，固定 autobuild 版本）"
-FFMPEG_VERSION="N-126482-g903325e279"
-FFMPEG_TARBALL="$BUILD_DIR/ffmpeg-${FFMPEG_VERSION}-linux64-gpl.tar.xz"
-FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-09-09-14-51/ffmpeg-${FFMPEG_VERSION}-linux64-gpl.tar.xz"
-FFMPEG_SHA256="746de35fdafb5d767a33d1068efb4bee5366edd71d60532d223620f40851e6e5"
+echo "==> 2/6 准备静态 ffmpeg（BtbN FFmpeg-Builds，latest release 的稳定分支资产）"
+FFMPEG_BRANCH="8.1"
+FFMPEG_ASSET="ffmpeg-n${FFMPEG_BRANCH}-latest-linux64-gpl-${FFMPEG_BRANCH}.tar.xz"
+FFMPEG_TARBALL="$BUILD_DIR/$FFMPEG_ASSET"
+FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/latest/download/$FFMPEG_ASSET"
+FFMPEG_CHECKSUMS="$BUILD_DIR/btbn-checksums.sha256"
 FFMPEG_DIR="$BUILD_DIR/ffmpeg-static"
 # 静态版自包含 libstdc++ 依赖，不受 PyInstaller 的 _internal 旧库污染；
 # 动态版 ffmpeg 若打进包内，AppRun 污染环境下照样会 GLIBCXX 报错。
-# BtbN autobuild 固定版本 + 写死 SHA256：版本与校验双固定，完全可复现；
-# 升级时改 FFMPEG_VERSION / FFMPEG_URL / FFMPEG_SHA256 三处即可
-# （checksums 见 https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-09-09-14-51）。
-# 注意：BtbN 只保留最近十来天的 dated autobuild，旧 release 会被删除（下载变 404），
-# 需要定期更新这里的 pin。
+# BtbN 只保留最近十来天的 dated autobuild release，写死 dated tag（连同其内
+# N-xxxx 版本与 SHA256）迟早被删成 404，2026-09-10 v1.6.0-beta.3 的 Linux
+# 打包即因此失败。`latest` release 永远存在且始终携带各稳定分支资产，
+# releases/latest/download/<asset> 是永久直链；n8.1 资产跟随 FFmpeg 8.1
+# 稳定分支维护更新，与 Windows（gyan 8.1.2）/ macOS（osxexperts 8.1）大版本
+# 对齐。内容随维护更新，无法写死 SHA256，改为随包下载上游 checksums.sha256
+# 比对完整性（curl --fail 保证 404 / 断流直接报错，不再静默存下错误页），
+# 解压后另校验 ffmpeg 自报版本包含分支号。升级大版本只改 FFMPEG_BRANCH。
 if [ ! -x "$FFMPEG_DIR/bin/ffmpeg" ]; then
-    if [ ! -f "$FFMPEG_TARBALL" ]; then
-        echo "    下载静态 ffmpeg..."
-        curl -sSfL --retry 3 --retry-delay 2 -o "$FFMPEG_TARBALL" "$FFMPEG_URL"
-    fi
-    echo "    校验静态 ffmpeg 完整性..."
-    if ! echo "$FFMPEG_SHA256  $FFMPEG_TARBALL" | sha256sum -c - >/dev/null; then
-        echo "错误：ffmpeg 下载校验和不匹配（$FFMPEG_TARBALL），已删除。" >&2
-        echo "错误：若 curl 已报 404，说明上游 dated autobuild 被清理，请更新 FFMPEG_VERSION / FFMPEG_URL / FFMPEG_SHA256 后重试。" >&2
+    echo "    下载静态 ffmpeg（$FFMPEG_ASSET）..."
+    if ! curl --fail --location --silent --show-error --retry 3 --retry-delay 2 \
+            -o "$FFMPEG_TARBALL" "$FFMPEG_URL"; then
+        echo "错误：ffmpeg 下载失败（$FFMPEG_URL）。" >&2
         rm -f "$FFMPEG_TARBALL"
         exit 1
     fi
+    echo "    对照上游 checksums.sha256 校验静态 ffmpeg 完整性..."
+    if ! curl --fail --location --silent --show-error --retry 3 --retry-delay 2 \
+            -o "$FFMPEG_CHECKSUMS" \
+            "https://github.com/BtbN/FFmpeg-Builds/releases/latest/download/checksums.sha256" \
+        || ! bash "$REPO_ROOT/scripts/verify_sha256.sh" "$FFMPEG_CHECKSUMS" "$FFMPEG_ASSET" "$FFMPEG_TARBALL"; then
+        echo "错误：ffmpeg 完整性校验失败或 checksums.sha256 不可得（$FFMPEG_TARBALL），已删除。" >&2
+        rm -f "$FFMPEG_TARBALL" "$FFMPEG_CHECKSUMS"
+        exit 1
+    fi
+    rm -f "$FFMPEG_CHECKSUMS"
     mkdir -p "$FFMPEG_DIR"
     tar -xf "$FFMPEG_TARBALL" -C "$FFMPEG_DIR" --strip-components=1
     chmod +x "$FFMPEG_DIR/bin/ffmpeg" "$FFMPEG_DIR/bin/ffprobe"
+fi
+# 资产名固定在 8.1 分支，仍校验二进制自报版本，防同名资产内容异常。
+"$FFMPEG_DIR/bin/ffmpeg" -version 2>&1 | head -n 1 | grep -q "$FFMPEG_BRANCH" || {
+    echo "错误：解压出的 ffmpeg 版本异常（未包含 $FFMPEG_BRANCH）：" >&2
+    "$FFMPEG_DIR/bin/ffmpeg" -version 2>&1 | head -n 1 >&2
+    exit 1
+}
+# 实际打进包的归档哈希写入 SOURCE.txt；复用缓存目录且归档已清理时如实标注。
+if [ -f "$FFMPEG_TARBALL" ]; then
+    FFMPEG_TARBALL_SHA256="$(sha256sum "$FFMPEG_TARBALL" | cut -d ' ' -f1)"
+else
+    FFMPEG_TARBALL_SHA256="unavailable (reused cached ffmpeg-static; archive not kept)"
 fi
 # 放入 PyInstaller onedir 产物：frozen 时 _bundled_ffmpeg_directory() 查
 # sys.executable.parent / ffmpeg / bin（即 dist/MAW/ffmpeg/bin）。BtbN 包内
@@ -80,10 +102,10 @@ grep -q "GNU GENERAL" "$_GPL_TMP" || { rm -f "$_GPL_TMP"; echo "GPL 许可证文
 mv -f "$_GPL_TMP" "$_GPL_TARGET"
 test -s "$_GPL_TARGET"
 cat > "dist/MAW/ffmpeg/SOURCE.txt" <<EOF
-FFmpeg $FFMPEG_VERSION — BtbN FFmpeg-Builds linux64-gpl static build
+FFmpeg n${FFMPEG_BRANCH}-latest (${FFMPEG_BRANCH} stable branch) — BtbN FFmpeg-Builds linux64-gpl static build
 Build provider: https://github.com/BtbN/FFmpeg-Builds
 Original archive: $FFMPEG_URL
-Archive SHA-256: $FFMPEG_SHA256
+Archive SHA-256: $FFMPEG_TARBALL_SHA256
 License: GPL-3.0 (full text in GPLv3.txt)
 Upstream FFmpeg source: https://github.com/FFmpeg/FFmpeg
 This MAW package includes only ffmpeg and ffprobe from the original build.
@@ -146,7 +168,7 @@ cp "$APP_DIR/MAW.desktop" "$APP_DIR/usr/share/applications/MAW.desktop"
 
 echo "==> 4/6 准备 appimagetool"
 if [ ! -x "$APPIMAGE_TOOL" ]; then
-    curl -sL --retry 3 --retry-delay 2 -o "$APPIMAGE_TOOL" "$APPIMAGE_URL"
+    curl --fail --location --silent --show-error --retry 3 --retry-delay 2 -o "$APPIMAGE_TOOL" "$APPIMAGE_URL"
     chmod +x "$APPIMAGE_TOOL"
     # 校验下载的是 ELF 二进制而非 HTML 错误页
     if ! file "$APPIMAGE_TOOL" | grep -q 'ELF'; then

--- a/scripts/verify_sha256.sh
+++ b/scripts/verify_sha256.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# 按 checksums 清单校验单个文件的 SHA-256。
+# 用法：verify_sha256.sh <checksums-file> <asset-name> <target-file>
+# 退出码：0 通过；1 清单或文件缺失、清单无该资产条目、哈希不匹配；2 用法错误。
+#
+# 上游 checksums（如 BtbN FFmpeg-Builds）每行只写裸文件名。把这种行直接喂给
+# `sha256sum -c` 时，文件名按调用方的当前目录解析，而下载物通常落在子目录
+# （build-appimage/ 之于仓库根），于是报 "No such file or directory"，被误判成
+# 完整性校验失败。这里对传入的目标路径自行计算哈希再比对，校验与当前目录无关。
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "用法：$0 <checksums-file> <asset-name> <target-file>" >&2
+    exit 2
+fi
+
+CHECKSUMS="$1"
+ASSET="$2"
+TARGET="$3"
+
+if [ ! -f "$CHECKSUMS" ]; then
+    echo "错误：checksums 清单不存在（$CHECKSUMS）。" >&2
+    exit 1
+fi
+if [ ! -f "$TARGET" ]; then
+    echo "错误：待校验文件不存在（$TARGET）。" >&2
+    exit 1
+fi
+
+EXPECTED="$(awk -v asset="$ASSET" '$2 == asset { print $1; exit }' "$CHECKSUMS")"
+if [ -z "$EXPECTED" ]; then
+    echo "错误：checksums 清单中没有 $ASSET 的条目（$CHECKSUMS）。" >&2
+    exit 1
+fi
+
+# GNU coreutils 在文件名含反斜杠时会给整行加前导 "\" 转义标记，剥掉它才拿到纯哈希。
+ACTUAL="$(sha256sum "$TARGET" | cut -d ' ' -f1)"
+ACTUAL="${ACTUAL#\\}"
+EXPECTED="${EXPECTED#\\}"
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "错误：SHA-256 不匹配（$TARGET）。" >&2
+    echo "  期望 $EXPECTED" >&2
+    echo "  实际 $ACTUAL" >&2
+    exit 1
+fi

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -475,7 +475,25 @@ class PackagingContractTests(unittest.TestCase):
         self.assertIn('https://www.gnu.org/licenses/gpl-3.0.txt', script)
         self.assertIn('raw.githubusercontent.com/spdx/license-list-data', script)
         self.assertIn('Build provider: https://github.com/BtbN/FFmpeg-Builds', script)
-        self.assertIn('Archive SHA-256: $FFMPEG_SHA256', script)
+        self.assertIn('Archive SHA-256: $FFMPEG_TARBALL_SHA256', script)
+
+    def test_appimage_build_pins_btbn_rolling_latest_not_dated_autobuild(self) -> None:
+        """Given the AppImage build script, When it downloads BtbN ffmpeg, Then it uses the permanent latest-release asset with upstream checksum verification instead of a dated pin that upstream prunes."""
+        script = read_text("scripts/build-appimage.sh")
+
+        self.assertIn("releases/latest/download/$FFMPEG_ASSET", script)
+        self.assertIn("releases/latest/download/checksums.sha256", script)
+        self.assertIn(
+            'bash "$REPO_ROOT/scripts/verify_sha256.sh" "$FFMPEG_CHECKSUMS" "$FFMPEG_ASSET" "$FFMPEG_TARBALL"',
+            script,
+        )
+        # 上游清单只写裸文件名，sha256sum -c 按当前目录解析，而归档落在 build-appimage/
+        # 子目录，必然报 No such file or directory（2026-09-10 Linux 打包即因此失败）。
+        self.assertNotIn("sha256sum -c", script)
+        self.assertIn("curl --fail --location --silent --show-error", script)
+        self.assertIn('| grep -q "$FFMPEG_BRANCH"', script)
+        self.assertNotIn("/releases/download/autobuild-", script)
+        self.assertNotIn("FFMPEG_SHA256=", script)
 
     def test_local_build_script_invokes_uv_and_pyinstaller_for_maw_onedir(self) -> None:
         """Given a Windows developer build, When the script is read, Then it builds dist/MAW/MAW.exe."""

--- a/tests/test_verify_sha256_script.py
+++ b/tests/test_verify_sha256_script.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify_sha256.sh"
+ASSET = "ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz"
+ARCHIVE_BYTES = b"tarball-bytes"
+
+
+def usable_bash() -> str | None:
+    """挑一个真能执行本脚本的 bash。
+
+    Windows 上 PATH 里排第一的往往是 WSL 的 bash，它看不到 ``C:\\`` 形式的仓库路径；
+    这里直接让它 ``test -f`` 本脚本，顺带确认 sha256sum/awk/grep 可用，读不到就跳过，
+    避免把维护者本机跑成一片红。Linux CI 上探测必然通过，测试真实执行。
+    """
+    candidate = shutil.which("bash")
+    if not candidate:
+        return None
+    probe = (
+        f'test -f "{VERIFIER.as_posix()}"'
+        " && command -v sha256sum >/dev/null"
+        " && command -v awk >/dev/null"
+        " && command -v grep >/dev/null"
+    )
+    try:
+        proc = subprocess.run([candidate, "-c", probe], capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return candidate if proc.returncode == 0 else None
+
+
+BASH = usable_bash()
+
+
+def manifest_line(name: str, digest: str) -> str:
+    """上游清单的一行：哈希 + 两个空格 + 裸文件名（不含任何路径成分）。"""
+    return f"{digest}  {name}\n"
+
+
+@unittest.skipUnless(BASH, "需要能读取仓库路径且带 sha256sum/awk/grep 的 bash（WSL bash 看不到 C:\\ 路径）")
+class VerifySha256ScriptTests(unittest.TestCase):
+    """Given the checksum verifier, When the manifest lists bare file names while the archive sits
+    in a sub-directory, Then it validates the target by the path it was given, and fails loudly on
+    tampered content, a missing entry, or a missing file."""
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        # 复刻 Linux 打包的目录布局：脚本从仓库根运行，归档落在 build-appimage/ 子目录
+        self.repo_root = Path(tmp.name) / "repo"
+        self.build_dir = self.repo_root / "build-appimage"
+        self.build_dir.mkdir(parents=True)
+        self.target = self.build_dir / ASSET
+        self.target.write_bytes(ARCHIVE_BYTES)
+        self.checksums = self.build_dir / "btbn-checksums.sha256"
+
+    def run_verifier(self, checksums: Path, asset: str, target: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [BASH, str(VERIFIER), str(checksums), asset, str(target)],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    def write_manifest(self, name: str = ASSET, digest: str | None = None) -> str:
+        resolved = hashlib.sha256(ARCHIVE_BYTES).hexdigest() if digest is None else digest
+        self.checksums.write_text(manifest_line(name, resolved), encoding="utf-8")
+        return resolved
+
+    def test_accepts_upstream_manifest_when_target_is_in_subdirectory(self) -> None:
+        self.write_manifest()
+
+        proc = self.run_verifier(self.checksums, ASSET, self.target)
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_plain_sha256sum_c_cannot_resolve_the_same_layout(self) -> None:
+        """钉住成因：同一份清单与目录布局，把裸文件名喂给 sha256sum -c 会按当前目录找不到归档。"""
+        self.write_manifest()
+
+        proc = subprocess.run(
+            [BASH, "-c", f'grep -F "{ASSET}" "{self.checksums}" | sha256sum -c -'],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+        self.assertNotEqual(proc.returncode, 0, "sha256sum -c 若能在仓库根解析裸文件名，本坑的说明需重写")
+        self.assertIn("No such file or directory", proc.stderr)
+
+    def test_rejects_tampered_archive(self) -> None:
+        self.write_manifest(digest=hashlib.sha256(b"someone-elses-bytes").hexdigest())
+
+        proc = self.run_verifier(self.checksums, ASSET, self.target)
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("SHA-256 不匹配", proc.stderr)
+
+    def test_does_not_accept_a_different_asset_sharing_the_name_as_substring(self) -> None:
+        self.write_manifest(name=f"old-{ASSET}")
+
+        proc = self.run_verifier(self.checksums, ASSET, self.target)
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn(f"没有 {ASSET} 的条目", proc.stderr)
+
+    def test_rejects_missing_manifest(self) -> None:
+        proc = self.run_verifier(self.checksums, ASSET, self.target)
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("checksums 清单不存在", proc.stderr)
+
+    def test_rejects_missing_archive(self) -> None:
+        self.write_manifest()
+        self.target.unlink()
+
+        proc = self.run_verifier(self.checksums, ASSET, self.target)
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("待校验文件不存在", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

AppImage 打包此前写死某个 BtbN dated autobuild 的下载地址与 SHA256。BtbN 只保留最近十来天的 dated release，过期即 404；而下载又没开 `--fail`，404 页面会被存成文件并报成「校验和不匹配」——1.6.0-beta.3 的 Linux 打包即因此失败。

## 改动

1. **改用永久直链**：`releases/latest/download/ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz`。`latest` release 永远存在且始终携带各稳定分支资产，n8.1 跟随 FFmpeg 8.1 稳定分支更新，与 Windows（gyan 8.1.2）/ macOS（osxexperts 8.1）大版本对齐。升级大版本只改脚本里的 `FFMPEG_BRANCH` 一处。
2. **下载一律带 `--fail`**：404 / 断流直接报错，不再静默存下错误页；appimagetool 的下载同样补上。
3. **完整性校验改为随包下载上游 `checksums.sha256` 比对**（资产内容随维护更新，无法再写死 SHA256），解压后另校验 ffmpeg 自报版本包含分支号；实际打进包的归档哈希仍记录在 `ffmpeg/SOURCE.txt`。
4. **校验实现独立成 `scripts/verify_sha256.sh`**。上游清单每行只写裸文件名，直接交给 `sha256sum -c` 时该名字是按调用方当前目录解析的，而归档落在 `build-appimage/` 子目录，于是必然报 `No such file or directory` 并被误判成完整性校验失败。新脚本对传入的目标路径自行计算哈希再比对，与当前目录无关，并剥掉 coreutils 给含反斜杠文件名加的前导转义标记。
5. **测试**。新增 `tests/test_verify_sha256_script.py`，用真实 bash 执行该脚本，覆盖「子目录归档可通过 / 内容被篡改被拒 / 仅前缀同名的条目不错取 / 清单或文件缺失被拒」，并把旧写法在同一目录布局下的失败一并钉进测试，说明这个脚本为什么必须存在。同时改写 `test_appimage_build_pins_btbn_rolling_latest_not_dated_autobuild`：原先把出错那一行原文 `assertIn` 进断言，锁住的是实现字符串而不是行为，所以完全拦不住。

## 验证

- 在 fork 上以 tag 触发 `Release MAW GUI`（run `34443976122`）：**Build Linux x86_64 ✓ 3m28s** —— `Build AppImage` → `Verify AppImage output` → `Verify no bundled C++ runtime` → `Verify bundled static ffmpeg under polluted environment` → `Smoke AppImage (headless)` 全过；Windows ✓，Publish ✓。
- 同轮 **Build macOS arm64 ✗** ：`curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR`，抓取 osxexperts.net 归档时被对端折断。该路径本 PR 未触碰，属该域名偶发网络抖动；内容相同的后续运行（run `34446163198`）三平台全绿。
- 本地：`tests.test_verify_sha256_script` 6 项 + `tests.test_packaging_contract` 27 项通过；`ruff check` 干净；`git diff --check` 干净；两个 `.sh` 通过 `bash -n`。行为测试对 bash 做探测式跳过（Windows 上 PATH 里排第一的常是 WSL bash，它读不到 `C:\` 形式的路径），Linux / macOS runner 上真实执行。
- `CHANGELOG.md` 已补 Unreleased → 🐛 修复一条。

## 影响范围

只有 Linux AppImage 打包路径（`scripts/build-appimage.sh` + 新脚本 + 对应测试）。运行时行为、JSON 工程契约、`web/` 前端均未改动，因此不涉及内联副本重生成。
